### PR TITLE
Add cancel state on donations

### DIFF
--- a/donation/donation.py
+++ b/donation/donation.py
@@ -288,8 +288,8 @@ class DonationDonation(models.Model):
 
         if (
                 self.env['res.users'].has_group(
-                    'account.group_supplier_inv_check_total')
-                and self.check_total != self.amount_total):
+                    'account.group_supplier_inv_check_total') and
+                self.check_total != self.amount_total):
             raise Warning(
                 _("The amount of the donation of %s (%s) is different from "
                     "the sum of the donation lines (%s).") % (
@@ -334,8 +334,8 @@ class DonationDonation(models.Model):
         '''from Cancel state to Draft state'''
         if self.move_id:
             raise Warning(
-                _('A cancelled donation should not be linked to an '
-                    'account move'))
+                _("A cancelled donation should not be linked to an "
+                  "account move"))
         self.state = 'draft'
         return
 
@@ -345,12 +345,12 @@ class DonationDonation(models.Model):
             if donation.state == 'done':
                 raise Warning(
                     _("The donation '%s' is in Done state, so you cannot "
-                        "delete it.")
+                      "delete it.")
                     % donation.number)
             if donation.move_id:
                 raise Warning(
                     _("The donation '%s' is linked to an account move, "
-                        "so you cannot delete it."))
+                      "so you cannot delete it."))
         return super(DonationDonation, self).unlink()
 
     @api.one

--- a/donation/donation.py
+++ b/donation/donation.py
@@ -140,7 +140,7 @@ class DonationDonation(models.Model):
     state = fields.Selection([
         ('draft', 'Draft'),
         ('done', 'Done'),
-        ('cancel', 'Cancel'),
+        ('cancel', 'Cancelled'),
         ], string='State', readonly=True, copy=False, default='draft',
         track_visibility='onchange')
     company_currency_id = fields.Many2one(
@@ -453,6 +453,6 @@ class AccountJournal(models.Model):
     def _check_donation(self):
         if self.allow_donation and self.type not in ('bank', 'cash'):
             raise Warning(
-                _("The journal '%s' has the option 'Allow Donation', "
-                    "so it's type should be 'Cash' or 'Bank and Checks.")
+                _("The journal '%s' has the option 'Donation Payment Method', "
+                    "so it's type should be 'Cash' or 'Bank and Checks'.")
                 % self.name)

--- a/donation/donation_view.xml
+++ b/donation/donation_view.xml
@@ -19,9 +19,12 @@
                     class="oe_highlight" states="draft"
                     groups="donation.group_donation_user"
                     invisible="context.get('recurring_view')"/>
-                <button type="object" name="back_to_draft"
-                    string="Back to Draft" states="done"
+                <button type="object" name="cancel2draft"
+                    string="Back to Draft" states="cancel"
                     groups="donation.group_donation_user"/>
+                <button type="object" name="done2cancel" string="Cancel"
+                    groups="donation.group_donation_user"
+                    states="done" invisible="context.get('recurring_view')"/>
                 <button type="object" name="save_default_values"
                     string="Save Default Values"/>
                 <field name="state" widget="statusbar"
@@ -81,7 +84,7 @@
     <field name="name">donation.tree</field>
     <field name="model">donation.donation</field>
     <field name="arch"  type="xml">
-        <tree string="Donation" colors="blue:state=='draft'">
+        <tree string="Donation" colors="blue:state=='draft';grey:state=='cancel'">
             <field name="number" invisible="context.get('recurring_view')"/>
             <field name="partner_id" invisible="context.get('partner_view')"/>
             <field name="donation_date"/>

--- a/donation/donation_view.xml
+++ b/donation/donation_view.xml
@@ -84,7 +84,7 @@
     <field name="name">donation.tree</field>
     <field name="model">donation.donation</field>
     <field name="arch"  type="xml">
-        <tree string="Donation" colors="blue:state=='draft';grey:state=='cancel'">
+        <tree string="Donation" colors="blue:state=='draft';purple:state=='cancel'">
             <field name="number" invisible="context.get('recurring_view')"/>
             <field name="partner_id" invisible="context.get('partner_view')"/>
             <field name="donation_date"/>

--- a/donation/i18n/donation.pot
+++ b/donation/i18n/donation.pot
@@ -6,14 +6,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-18 20:36+0000\n"
-"PO-Revision-Date: 2015-02-18 20:36+0000\n"
+"POT-Creation-Date: 2015-05-29 23:06+0000\n"
+"PO-Revision-Date: 2015-05-29 23:06+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: donation
+#: code:addons/donation/donation.py:337
+#, python-format
+msgid "A cancelled donation should not be linked to an account move"
+msgstr ""
 
 #. module: donation
 #: field:donation.donation,move_id:0
@@ -61,18 +67,30 @@ msgid "Campaign"
 msgstr ""
 
 #. module: donation
+#: view:donation.donation:donation.donation_form
 #: view:donation.validate:donation.donation_validate_form
 msgid "Cancel"
 msgstr ""
 
 #. module: donation
-#: code:addons/donation/donation.py:279
+#: selection:donation.donation,state:0
+msgid "Cancelled"
+msgstr ""
+
+#. module: donation
+#: code:addons/donation/donation.py:362
+#, python-format
+msgid "Cancelled Donation of %s"
+msgstr ""
+
+#. module: donation
+#: code:addons/donation/donation.py:281
 #, python-format
 msgid "Cannot validate the donation of %s because it doesn't have any lines!"
 msgstr ""
 
 #. module: donation
-#: code:addons/donation/donation.py:284
+#: code:addons/donation/donation.py:286
 #, python-format
 msgid "Cannot validate the donation of %s because it is not in draft state."
 msgstr ""
@@ -166,6 +184,7 @@ msgstr ""
 #: view:donation.donation:donation.donation_form
 #: view:donation.donation:donation.donation_tree
 #: field:donation.line,donation_id:0
+#: model:ir.model,name:donation.model_donation_donation
 #: model:ir.module.category,name:donation.module_category_donation
 #: view:product.template:donation.product_template_search_view
 #: model:product.template,name:donation.product_product_donation_product_template
@@ -223,7 +242,7 @@ msgid "Donation Validated"
 msgstr ""
 
 #. module: donation
-#: code:addons/donation/donation.py:166
+#: code:addons/donation/donation.py:168
 #, python-format
 msgid "Donation of %s"
 msgstr ""
@@ -232,7 +251,6 @@ msgstr ""
 #: view:donation.donation:donation.donation_graph
 #: model:ir.actions.act_window,name:donation.donation_action
 #: model:ir.actions.act_window,name:donation.partner_donation_action
-#: model:ir.model,name:donation.model_donation_donation
 #: model:ir.ui.menu,name:donation.donation_menu
 #: model:ir.ui.menu,name:donation.donation_report_title_menu
 #: model:ir.ui.menu,name:donation.donation_title_menu
@@ -280,7 +298,7 @@ msgid "Draft"
 msgstr ""
 
 #. module: donation
-#: code:addons/donation/donation.py:343
+#: code:addons/donation/donation.py:360
 #, python-format
 msgid "Draft Donation of %s"
 msgstr ""
@@ -291,7 +309,7 @@ msgid "Followers"
 msgstr ""
 
 #. module: donation
-#: code:addons/donation/donation.py:308
+#: code:addons/donation/donation.py:310
 #, python-format
 msgid "Full in-kind donation: no account move generated"
 msgstr ""
@@ -391,13 +409,13 @@ msgid "Messages and communication history"
 msgstr ""
 
 #. module: donation
-#: code:addons/donation/donation.py:173
+#: code:addons/donation/donation.py:175
 #, python-format
 msgid "Missing Default Debit Account on journal '%s'."
 msgstr ""
 
 #. module: donation
-#: code:addons/donation/donation.py:202
+#: code:addons/donation/donation.py:204
 #, python-format
 msgid "Missing income account on product '%s' or on it's related product category"
 msgstr ""
@@ -507,27 +525,33 @@ msgid "Summary"
 msgstr ""
 
 #. module: donation
-#: code:addons/donation/donation.py:292
+#: code:addons/donation/donation.py:294
 #, python-format
 msgid "The amount of the donation of %s (%s) is different from the sum of the donation lines (%s)."
 msgstr ""
 
 #. module: donation
-#: code:addons/donation/donation.py:160
+#: code:addons/donation/donation.py:162
 #, python-format
 msgid "The date of the donation of %s should be today or in the past, not in the future!"
 msgstr ""
 
 #. module: donation
-#: code:addons/donation/donation.py:334
+#: code:addons/donation/donation.py:347
 #, python-format
-msgid "The donation '%s' is in Done state, so you must set it back to draft before deleting it."
+msgid "The donation '%s' is in Done state, so you cannot delete it."
 msgstr ""
 
 #. module: donation
-#: code:addons/donation/donation.py:437
+#: code:addons/donation/donation.py:352
 #, python-format
-msgid "The journal '%s' has the option 'Allow Donation', so it's type should be 'Cash' or 'Bank and Checks."
+msgid "The donation '%s' is linked to an account move, so you cannot delete it."
+msgstr ""
+
+#. module: donation
+#: code:addons/donation/donation.py:456
+#, python-format
+msgid "The journal '%s' has the option 'Donation Payment Method', so it's type should be 'Cash' or 'Bank and Checks'."
 msgstr ""
 
 #. module: donation

--- a/donation/i18n/fr.po
+++ b/donation/i18n/fr.po
@@ -6,14 +6,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-18 20:37+0000\n"
-"PO-Revision-Date: 2015-02-18 20:37+0000\n"
+"POT-Creation-Date: 2015-05-29 23:07+0000\n"
+"PO-Revision-Date: 2015-05-29 23:07+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: donation
+#: code:addons/donation/donation.py:337
+#, python-format
+msgid "A cancelled donation should not be linked to an account move"
+msgstr "Un don annulé ne devrait pas être lié à une écriture comptable"
 
 #. module: donation
 #: field:donation.donation,move_id:0
@@ -61,21 +67,33 @@ msgid "Campaign"
 msgstr "Campagne de don"
 
 #. module: donation
+#: view:donation.donation:donation.donation_form
 #: view:donation.validate:donation.donation_validate_form
 msgid "Cancel"
-msgstr "Cancel"
+msgstr "Annuler"
 
 #. module: donation
-#: code:addons/donation/donation.py:279
+#: selection:donation.donation,state:0
+msgid "Cancelled"
+msgstr "Annulé"
+
+#. module: donation
+#: code:addons/donation/donation.py:362
+#, python-format
+msgid "Cancelled Donation of %s"
+msgstr "Don annulé de %s"
+
+#. module: donation
+#: code:addons/donation/donation.py:281
 #, python-format
 msgid "Cannot validate the donation of %s because it doesn't have any lines!"
-msgstr "Cannot validate the donation of %s because it doesn't have any lines!"
+msgstr "Impossible de valider le don de %s parce qu'il ne contient aucune ligne !"
 
 #. module: donation
-#: code:addons/donation/donation.py:284
+#: code:addons/donation/donation.py:286
 #, python-format
 msgid "Cannot validate the donation of %s because it is not in draft state."
-msgstr "Cannot validate the donation of %s because it is not in draft state."
+msgstr "Impossible de valider le don de %s parce qu'il n'est pas à l'état brouillon."
 
 #. module: donation
 #: field:donation.report,product_categ_id:0
@@ -112,7 +130,7 @@ msgstr "Configuration"
 #. module: donation
 #: field:donation.donation,country_id:0
 msgid "Country"
-msgstr "Country"
+msgstr "Pays"
 
 #. module: donation
 #: field:donation.campaign,create_uid:0
@@ -128,7 +146,7 @@ msgstr "Créé par"
 #: field:donation.line,create_date:0
 #: field:donation.validate,create_date:0
 msgid "Created on"
-msgstr "Created on"
+msgstr "Créé le"
 
 #. module: donation
 #: view:donation.donation:donation.donation_search
@@ -144,7 +162,7 @@ msgstr "Campagne de don courante"
 #. module: donation
 #: field:res.users,context_donation_journal_id:0
 msgid "Current Donation Payment Method"
-msgstr "Current Donation Payment Method"
+msgstr "Méthode de paiement actuelle"
 
 #. module: donation
 #: view:donation.donation:donation.donation_search
@@ -160,12 +178,13 @@ msgstr "Date of the last message posted on the record."
 #. module: donation
 #: field:donation.campaign,display_name:0
 msgid "Display Name"
-msgstr "Display Name"
+msgstr "Nom affiché"
 
 #. module: donation
 #: view:donation.donation:donation.donation_form
 #: view:donation.donation:donation.donation_tree
 #: field:donation.line,donation_id:0
+#: model:ir.model,name:donation.model_donation_donation
 #: model:ir.module.category,name:donation.module_category_donation
 #: view:product.template:donation.product_template_search_view
 #: model:product.template,name:donation.product_product_donation_product_template
@@ -214,25 +233,24 @@ msgstr "Numéro de don"
 #. module: donation
 #: field:account.journal,allow_donation:0
 msgid "Donation Payment Method"
-msgstr "Donation Payment Method"
+msgstr "Méthode de paiement de don"
 
 #. module: donation
 #: model:mail.message.subtype,description:donation.donation_done
 #: model:mail.message.subtype,name:donation.donation_done
 msgid "Donation Validated"
-msgstr "Donation Validated"
+msgstr "Don validé"
 
 #. module: donation
-#: code:addons/donation/donation.py:166
+#: code:addons/donation/donation.py:168
 #, python-format
 msgid "Donation of %s"
-msgstr "Donation of %s"
+msgstr "Don de %s"
 
 #. module: donation
 #: view:donation.donation:donation.donation_graph
 #: model:ir.actions.act_window,name:donation.donation_action
 #: model:ir.actions.act_window,name:donation.partner_donation_action
-#: model:ir.model,name:donation.model_donation_donation
 #: model:ir.ui.menu,name:donation.donation_menu
 #: model:ir.ui.menu,name:donation.donation_report_title_menu
 #: model:ir.ui.menu,name:donation.donation_title_menu
@@ -280,10 +298,10 @@ msgid "Draft"
 msgstr "Brouillon"
 
 #. module: donation
-#: code:addons/donation/donation.py:343
+#: code:addons/donation/donation.py:360
 #, python-format
 msgid "Draft Donation of %s"
-msgstr "Draft Donation of %s"
+msgstr "Don brouillon de %s"
 
 #. module: donation
 #: field:donation.donation,message_follower_ids:0
@@ -291,10 +309,10 @@ msgid "Followers"
 msgstr "Followers"
 
 #. module: donation
-#: code:addons/donation/donation.py:308
+#: code:addons/donation/donation.py:310
 #, python-format
 msgid "Full in-kind donation: no account move generated"
-msgstr "Full in-kind donation: no account move generated"
+msgstr "Don en nature: aucune écriture comptable générée"
 
 #. module: donation
 #: view:donation.donation:donation.donation_search
@@ -360,7 +378,7 @@ msgstr "Last Message Date"
 #: field:donation.line,write_uid:0
 #: field:donation.validate,write_uid:0
 msgid "Last Updated by"
-msgstr "Last Updated by"
+msgstr "Dernière mise à jour par"
 
 #. module: donation
 #: field:donation.campaign,write_date:0
@@ -368,7 +386,7 @@ msgstr "Last Updated by"
 #: field:donation.line,write_date:0
 #: field:donation.validate,write_date:0
 msgid "Last Updated on"
-msgstr "Last Updated on"
+msgstr "Dernière mise à jour le"
 
 #. module: donation
 #: model:ir.module.category,description:donation.module_category_donation
@@ -391,16 +409,16 @@ msgid "Messages and communication history"
 msgstr "Messages and communication history"
 
 #. module: donation
-#: code:addons/donation/donation.py:173
+#: code:addons/donation/donation.py:175
 #, python-format
 msgid "Missing Default Debit Account on journal '%s'."
-msgstr "Missing Default Debit Account on journal '%s'."
+msgstr "Compte de débit par défaut manquant sur le journal '%s'."
 
 #. module: donation
-#: code:addons/donation/donation.py:202
+#: code:addons/donation/donation.py:204
 #, python-format
 msgid "Missing income account on product '%s' or on it's related product category"
-msgstr "Missing income account on product '%s' or on it's related product category"
+msgstr "Compte de produit manquant sur l'article '%s' ou sur sa catégorie interne associée"
 
 #. module: donation
 #: field:donation.campaign,name:0
@@ -415,7 +433,7 @@ msgstr "Notes"
 #. module: donation
 #: view:donation.donation:donation.donation_form
 msgid "Other Information"
-msgstr "Other Information"
+msgstr "Autres informations"
 
 #. module: donation
 #: view:donation.donation:donation.donation_search
@@ -429,7 +447,7 @@ msgstr "Partenaire"
 #: view:donation.report:donation.donation_report_search
 #: field:donation.report,country_id:0
 msgid "Partner Country"
-msgstr "Partner Country"
+msgstr "Pays du partenaire"
 
 #. module: donation
 #: view:donation.donation:donation.donation_search
@@ -440,7 +458,7 @@ msgstr "Méthode de paiement"
 #. module: donation
 #: field:donation.donation,payment_ref:0
 msgid "Payment Reference"
-msgstr "Payment Reference"
+msgstr "Référence du paiement"
 
 #. module: donation
 #: field:donation.line,product_id:0
@@ -448,17 +466,17 @@ msgstr "Payment Reference"
 #: field:donation.report,product_id:0
 #: model:ir.model,name:donation.model_product_product
 msgid "Product"
-msgstr "Produit"
+msgstr "Article"
 
 #. module: donation
 #: view:donation.report:donation.donation_report_search
 msgid "Product Category"
-msgstr "Catégorie de produit"
+msgstr "Catégorie d'article"
 
 #. module: donation
 #: model:ir.model,name:donation.model_product_template
 msgid "Product Template"
-msgstr "Product Template"
+msgstr "Modèle d'article"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_product_action
@@ -474,7 +492,7 @@ msgstr "Quantité"
 #. module: donation
 #: view:donation.donation:donation.donation_form
 msgid "Save Default Values"
-msgstr "Save Default Values"
+msgstr "Enregistrer les valeurs par défaut"
 
 #. module: donation
 #: view:donation.donation:donation.donation_search
@@ -504,41 +522,47 @@ msgstr "État"
 #. module: donation
 #: field:donation.donation,message_summary:0
 msgid "Summary"
-msgstr "Summary"
+msgstr "Résumé"
 
 #. module: donation
-#: code:addons/donation/donation.py:292
+#: code:addons/donation/donation.py:294
 #, python-format
 msgid "The amount of the donation of %s (%s) is different from the sum of the donation lines (%s)."
-msgstr "The amount of the donation of %s (%s) is different from the sum of the donation lines (%s)."
+msgstr "Le montant du don de %s (%s) est différent de la somme des lignes de don (%s)."
 
 #. module: donation
-#: code:addons/donation/donation.py:160
+#: code:addons/donation/donation.py:162
 #, python-format
 msgid "The date of the donation of %s should be today or in the past, not in the future!"
-msgstr "The date of the donation of %s should be today or in the past, not in the future!"
+msgstr "La date du don de %s devrait être aujourd'hui ou dans le passé, pas dans le futur !"
 
 #. module: donation
-#: code:addons/donation/donation.py:334
+#: code:addons/donation/donation.py:347
 #, python-format
-msgid "The donation '%s' is in Done state, so you must set it back to draft before deleting it."
-msgstr "The donation '%s' is in Done state, so you must set it back to draft before deleting it."
+msgid "The donation '%s' is in Done state, so you cannot delete it."
+msgstr "Le don '%s' est à l'état validé, donc vous ne pouvez pas le supprimer."
 
 #. module: donation
-#: code:addons/donation/donation.py:437
+#: code:addons/donation/donation.py:352
 #, python-format
-msgid "The journal '%s' has the option 'Allow Donation', so it's type should be 'Cash' or 'Bank and Checks."
-msgstr "The journal '%s' has the option 'Allow Donation', so it's type should be 'Cash' or 'Bank and Checks."
+msgid "The donation '%s' is linked to an account move, so you cannot delete it."
+msgstr "Le don '%s' est lié à une écriture comptable, donc vous ne pouvez pas le supprimer."
+
+#. module: donation
+#: code:addons/donation/donation.py:456
+#, python-format
+msgid "The journal '%s' has the option 'Donation Payment Method', so it's type should be 'Cash' or 'Bank and Checks'."
+msgstr "Le journal '%s' a l'option 'Méthode de paiement de don', donc il doit être de type 'Espèce' ou 'Banque et chèque'."
 
 #. module: donation
 #: model:product.template,description:donation.product_product_donation_product_template
 msgid "This is a donation product."
-msgstr "This is a donation product."
+msgstr "Ceci est un article de don."
 
 #. module: donation
 #: view:donation.validate:donation.donation_validate_form
 msgid "This wizard will validate all the draft donations selected."
-msgstr "This wizard will validate all the draft donations selected."
+msgstr "Cet assistant validera tous les dons brouillons sélectionnés."
 
 #. module: donation
 #: field:donation.line,unit_price:0
@@ -569,10 +593,10 @@ msgstr "Valider"
 #: view:donation.validate:donation.donation_validate_form
 #: model:ir.model,name:donation.model_donation_validate
 msgid "Validate Donations"
-msgstr "Validate Donations"
+msgstr "Valider les dons"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_validate_action
 msgid "Validate Draft Donations"
-msgstr "Validate Draft Donations"
+msgstr "Valider les dons brouillons"
 

--- a/donation_bank_statement/bank_statement.py
+++ b/donation_bank_statement/bank_statement.py
@@ -81,9 +81,9 @@ class AccountBankStatement(models.Model):
             if stline.amount > 0 and not stline.donation_ids:
                 for mline in stline.journal_entry_id.line_id:
                     if (
-                            mline.credit > 0
-                            and mline.account_id == transit_account
-                            and not mline.reconcile_id):
+                            mline.credit > 0 and
+                            mline.account_id == transit_account and
+                            not mline.reconcile_id):
                         if not stline.partner_id:
                             raise Warning(
                                 _("Missing partner on bank statement line "

--- a/donation_bank_statement/donation.py
+++ b/donation_bank_statement/donation.py
@@ -43,8 +43,8 @@ class DonationDonation(models.Model):
             transit_account = self.journal_id.default_debit_account_id
             for donation_mline in self.move_id.line_id:
                 if (
-                        donation_mline.account_id == transit_account
-                        and not donation_mline.reconcile_id):
+                        donation_mline.account_id == transit_account and
+                        not donation_mline.reconcile_id):
                     donation_mline_rec = donation_mline
                     logger.info(
                         'Found donation move line to reconcile ID=%d'
@@ -53,8 +53,8 @@ class DonationDonation(models.Model):
             for statement_mline in\
                     self.bank_statement_line_id.journal_entry_id.line_id:
                 if (
-                        statement_mline.account_id == transit_account
-                        and not statement_mline.reconcile_id):
+                        statement_mline.account_id == transit_account and
+                        not statement_mline.reconcile_id):
                     statement_mline_rec = statement_mline
                     logger.info(
                         'Found bank statement move line to reconcile ID=%d'

--- a/donation_direct_debit/donation.py
+++ b/donation_direct_debit/donation.py
@@ -119,17 +119,19 @@ class DonationDonation(models.Model):
         return res
 
     @api.one
-    def back_to_draft(self):
+    def done2cancel(self):
         if self.move_id:
             donation_mv_line_ids = [l.id for l in self.move_id.line_id]
             if donation_mv_line_ids:
                 plines = self.env['payment.line'].search([
-                    ('move_line_id', 'in', donation_mv_line_ids)])
+                    ('move_line_id', 'in', donation_mv_line_ids),
+                    ('order_id.state', 'in', ('draft', 'open')),
+                    ])
                 if plines:
                     raise Warning(
-                        _("You cannot set back to draft a donation "
+                        _("You cannot cancel a donation "
                             "which is linked to a payment line in a "
                             "direct debit order. Remove it from the "
                             "following direct debit order: %s.")
                         % plines[0].order_id.reference)
-        return super(DonationDonation, self).back_to_draft()
+        return super(DonationDonation, self).done2cancel()

--- a/donation_direct_debit/i18n/donation_direct_debit.pot
+++ b/donation_direct_debit/i18n/donation_direct_debit.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-03-14 11:15+0000\n"
-"PO-Revision-Date: 2015-03-14 11:15+0000\n"
+"POT-Creation-Date: 2015-05-29 23:00+0000\n"
+"PO-Revision-Date: 2015-05-29 23:00+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -29,7 +29,7 @@ msgstr ""
 
 #. module: donation_direct_debit
 #: model:ir.model,name:donation_direct_debit.model_donation_donation
-msgid "Donations"
+msgid "Donation"
 msgstr ""
 
 #. module: donation_direct_debit
@@ -47,5 +47,11 @@ msgstr ""
 #: code:addons/donation_direct_debit/donation.py:92
 #, python-format
 msgid "There are 2 payment modes with the same bank journal!"
+msgstr ""
+
+#. module: donation_direct_debit
+#: code:addons/donation_direct_debit/donation.py:132
+#, python-format
+msgid "You cannot cancel a donation which is linked to a payment line in a direct debit order. Remove it from the following direct debit order: %s."
 msgstr ""
 

--- a/donation_direct_debit/i18n/fr.po
+++ b/donation_direct_debit/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-03-14 11:15+0000\n"
-"PO-Revision-Date: 2015-03-14 11:15+0000\n"
+"POT-Creation-Date: 2015-05-29 23:01+0000\n"
+"PO-Revision-Date: 2015-05-29 23:01+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -29,8 +29,8 @@ msgstr "Une nouvelle ligne de paiement a été automatiquement ajoutée à l'ord
 
 #. module: donation_direct_debit
 #: model:ir.model,name:donation_direct_debit.model_donation_donation
-msgid "Donations"
-msgstr "Dons"
+msgid "Donation"
+msgstr "Don"
 
 #. module: donation_direct_debit
 #: field:donation.donation,mandate_id:0
@@ -48,4 +48,10 @@ msgstr "Aucun mandat valide trouvé pour le donateur %s"
 #, python-format
 msgid "There are 2 payment modes with the same bank journal!"
 msgstr "Il y a 2 modes de paiements liés au même journal de banque !"
+
+#. module: donation_direct_debit
+#: code:addons/donation_direct_debit/donation.py:132
+#, python-format
+msgid "You cannot cancel a donation which is linked to a payment line in a direct debit order. Remove it from the following direct debit order: %s."
+msgstr "Vous ne pouvez pas annuler un don lié à une ligne de paiement d'un ordre de prélèvement. Vous devez la supprimer de l'ordre de prélèvement %s."
 

--- a/donation_recurring/donation.py
+++ b/donation_recurring/donation.py
@@ -64,6 +64,8 @@ class DonationDonation(models.Model):
                     self.partner_id.name)
             else:
                 name = _('Draft Donation of %s') % self.partner_id.name
+        elif self.state == 'cancel':
+            name = _('Cancelled Donation of %s') % self.partner_id.name
         else:
             name = self.number
         self.display_name = name

--- a/donation_recurring/donation_view.xml
+++ b/donation_recurring/donation_view.xml
@@ -33,7 +33,7 @@
                 invisible="not context.get('recurring_view')"/>
         </field>
         <xpath expr="/tree" position="attributes">
-            <attribute name="colors">red:recurring_template=='suspended';blue:state=='draft'</attribute>
+            <attribute name="colors">red:recurring_template=='suspended';blue:state=='draft';purple:state=='cancel'</attribute>
         </xpath>
     </field>
 </record>

--- a/donation_tax_receipt/donation_tax.py
+++ b/donation_tax_receipt/donation_tax.py
@@ -83,14 +83,15 @@ class DonationDonation(models.Model):
         return res
 
     @api.one
-    def back_to_draft(self):
+    def done2cancel(self):
         if self.tax_receipt_id:
             raise Warning(
-                _("You cannot set this donation back to draft because "
+                _("You cannot cancel this donation because "
                     "it is linked to the tax receipt %s. You should first "
-                    "delete this tax receipt.")
+                    "delete this tax receipt (but it may not be legally "
+                    "allowed).")
                 % self.tax_receipt_id.number)
-        return super(DonationDonation, self).back_to_draft()
+        return super(DonationDonation, self).done2cancel()
 
     @api.onchange('partner_id')
     def partner_id_change(self):

--- a/donation_tax_receipt/donation_tax.py
+++ b/donation_tax_receipt/donation_tax.py
@@ -74,9 +74,9 @@ class DonationDonation(models.Model):
     def validate(self):
         res = super(DonationDonation, self).validate()
         if (
-                self.tax_receipt_option == 'each'
-                and self.tax_receipt_total
-                and not self.tax_receipt_id):
+                self.tax_receipt_option == 'each' and
+                self.tax_receipt_total and
+                not self.tax_receipt_id):
             receipt_vals = self._prepare_tax_receipt()
             receipt = self.env['donation.tax.receipt'].create(receipt_vals)
             self.tax_receipt_id = receipt.id
@@ -103,9 +103,9 @@ class DonationDonation(models.Model):
     def tax_receipt_option_change(self):
         res = {}
         if (
-                self.partner_id
-                and self.partner_id.tax_receipt_option == 'annual'
-                and self.tax_receipt_option != 'annual'):
+                self.partner_id and
+                self.partner_id.tax_receipt_option == 'annual' and
+                self.tax_receipt_option != 'annual'):
             res = {
                 'warning': {
                     'title': _('Error:'),

--- a/donation_tax_receipt/i18n/donation_tax_receipt.pot
+++ b/donation_tax_receipt/i18n/donation_tax_receipt.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-17 22:39+0000\n"
-"PO-Revision-Date: 2015-02-17 22:39+0000\n"
+"POT-Creation-Date: 2015-05-29 23:25+0000\n"
+"PO-Revision-Date: 2015-05-29 23:25+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -84,6 +84,11 @@ msgid "Date:"
 msgstr ""
 
 #. module: donation_tax_receipt
+#: model:ir.model,name:donation_tax_receipt.model_donation_donation
+msgid "Donation"
+msgstr ""
+
+#. module: donation_tax_receipt
 #: model:product.template,name:donation_tax_receipt.product_product_donation_notaxreceipt_product_template
 msgid "Donation - no tax receipt"
 msgstr ""
@@ -115,8 +120,8 @@ msgid "Donation Taxes Receipts"
 msgstr ""
 
 #. module: donation_tax_receipt
-#: model:ir.model,name:donation_tax_receipt.model_donation_donation
-msgid "Donations"
+#: model:ir.model,name:donation_tax_receipt.model_donation_report
+msgid "Donations Analysis"
 msgstr ""
 
 #. module: donation_tax_receipt
@@ -130,7 +135,14 @@ msgid "Donor:"
 msgstr ""
 
 #. module: donation_tax_receipt
+#: field:donation.donation,tax_receipt_total:0
+msgid "Eligible Tax Receipt Sub-total"
+msgstr ""
+
+#. module: donation_tax_receipt
 #: field:donation.line,tax_receipt_ok:0
+#: view:donation.report:donation_tax_receipt.donation_report_search
+#: field:donation.report,tax_receipt_ok:0
 #: view:product.template:donation_tax_receipt.product_template_search_view
 msgid "Eligible for a Tax Receipt"
 msgstr ""
@@ -141,7 +153,7 @@ msgid "End Date"
 msgstr ""
 
 #. module: donation_tax_receipt
-#: code:addons/donation_tax_receipt/donation_tax.py:109
+#: code:addons/donation_tax_receipt/donation_tax.py:111
 #, python-format
 msgid "Error:"
 msgstr ""
@@ -291,11 +303,6 @@ msgid "Tax Receipt Option"
 msgstr ""
 
 #. module: donation_tax_receipt
-#: field:donation.donation,tax_receipt_total:0
-msgid "Eligible Tax Receipt Sub-total"
-msgstr ""
-
-#. module: donation_tax_receipt
 #: model:ir.model,name:donation_tax_receipt.model_donation_tax_receipt
 msgid "Tax Receipt for Donations"
 msgstr ""
@@ -329,14 +336,14 @@ msgid "Type"
 msgstr ""
 
 #. module: donation_tax_receipt
-#: code:addons/donation_tax_receipt/donation_tax.py:111
+#: code:addons/donation_tax_receipt/donation_tax.py:89
 #, python-format
-msgid "You cannot change the Tax Receipt Option when it is Annual."
+msgid "You cannot cancel this donation because it is linked to the tax receipt %s. You should first delete this tax receipt (but it may not be legally allowed)."
 msgstr ""
 
 #. module: donation_tax_receipt
-#: code:addons/donation_tax_receipt/donation_tax.py:88
+#: code:addons/donation_tax_receipt/donation_tax.py:113
 #, python-format
-msgid "You cannot set this donation back to draft because it is linked to the tax receipt %s. You should first delete this tax receipt."
+msgid "You cannot change the Tax Receipt Option when it is Annual."
 msgstr ""
 


### PR DESCRIPTION
This "cancel" state on donation is very convenient for donation via direct debit where the direct debit has been rejected : it allows to keep a donation as "cancel", which is good to keep the history.

Allow to cancel donations linked to a payment line in done state.
