### PR TITLE
8.0 FIX invalidation of tax_receipt_total on donation.donation

### DIFF
--- a/donation_tax_receipt/donation_tax.py
+++ b/donation_tax_receipt/donation_tax.py
@@ -31,7 +31,7 @@ class DonationDonation(models.Model):
     @api.one
     @api.depends(
         'line_ids', 'line_ids.quantity', 'line_ids.unit_price',
-        'line_ids.product_id')
+        'line_ids.tax_receipt_ok')
     def _tax_receipt_total(self):
         total = 0.0
         # Do not consider other currencies for tax receipts


### PR DESCRIPTION
The problem can be seen when you create donations from a bank statement : the tax_receipt_total is always 0. This patch fixes the invalidation.
