### PR TITLE
[FIX] donation: Fix Transifex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - ODOO_REPO="odoo/odoo" LINT_CHECK="0"
-  - ODOO_REPO="OCA/OCB" LINT_CHECK="0"
+  - ODOO_REPO="odoo/odoo" LINT_CHECK="0" TESTS="1"
+  - ODOO_REPO="OCA/OCB" LINT_CHECK="0" TESTS="1"
 
 virtualenv:
   system_site_packages: true

--- a/donation/demo/donation_demo.xml
+++ b/donation/demo/donation_demo.xml
@@ -2,6 +2,15 @@
 
 <odoo noupdate="1">
 
+    <!-- This is needed for assuring a chart template is installed -->
+
+    <record id="base.main_company" model="res.company">
+        <field name="country_id" ref="base.fr"/>
+    </record>
+
+    <function model="donation.donation" name="auto_install_l10n"/>
+
+    <!-- END -->
 
 <record id="quest_origin" model="donation.campaign">
     <field name="code">Q1</field>

--- a/donation/models/donation.py
+++ b/donation/models/donation.py
@@ -457,6 +457,7 @@ class DonationDonation(models.Model):
             self.tax_receipt_option = 'annual'
         return res
 
+    @api.model
     def auto_install_l10n(self):
         """Helper function for calling a method that is not accessible directly
         from XML data.

--- a/donation/models/donation.py
+++ b/donation/models/donation.py
@@ -6,6 +6,7 @@
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import float_is_zero, float_compare
+from odoo.addons.account import _auto_install_l10n
 
 
 class DonationDonation(models.Model):
@@ -455,6 +456,12 @@ class DonationDonation(models.Model):
                 }
             self.tax_receipt_option = 'annual'
         return res
+
+    def auto_install_l10n(self):
+        """Helper function for calling a method that is not accessible directly
+        from XML data.
+        """
+        _auto_install_l10n(self.env.cr, None)
 
 
 class DonationLine(models.Model):


### PR DESCRIPTION
DB with demo data can't be populated with current state, as there's no chart template, and donation demo data searches for a journal, which is not present if no localization module is installed.

This trick assigns before that demo data a country to the main company and execute again the autoinstall function through a helper method.

Check log to see the root cause, although green: https://travis-ci.org/OCA/donation/jobs/291864901#L1431, which makes Transifex resources to be empty.