### PR TITLE
[FIX] donation: groups on view

### DIFF
--- a/donation_base/views/partner.xml
+++ b/donation_base/views/partner.xml
@@ -17,6 +17,7 @@
     <record id="view_partner_property_form" model="ir.ui.view">
         <field name="name">donation.tax.receipt.res.partner.form</field>
         <field name="model">res.partner</field>
+        <field name="groups_id" eval="[(4, ref('base.group_system')), (4, ref('account.group_account_invoice'))]"/>
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <field name="property_account_position_id" position="after">


### PR DESCRIPTION
Was causing permision problems in the `res.partner` form.

@alexis-via @etobella 