### PR TITLE
[OU] donation: Add migration script

### DIFF
--- a/donation/migrations/14.0.1.0.0/pre-migration.py
+++ b/donation/migrations/14.0.1.0.0/pre-migration.py
@@ -1,0 +1,26 @@
+# Copyright 2022 CreuBlanca
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.column_exists(
+        env.cr, "res_users", "context_donation_payment_mode_id"
+    ):
+        openupgrade.add_fields(
+            env,
+            [
+                (
+                    "context_donation_payment_mode_id",
+                    "res.users",
+                    "res_users",
+                    "many2one",
+                    False,
+                    "donation",
+                )
+            ],
+        )
+        openupgrade.drop_columns(
+            env.cr, [("res_users", "context_donation_payment_mode_id")]
+        )


### PR DESCRIPTION
The following error is raised when migrated otherwise:

```
2022-06-07 11:27:20,591 1 INFO devel odoo.modules.registry: module donation: creating or updating database tables 
2022-06-07 11:27:20,624 1 ERROR devel odoo.sql_db: bad query: 
                SELECT substr(p.res_id, 11)::integer, r.id
                FROM ir_property p
                LEFT JOIN account_payment_mode r ON substr(p.value_reference, 22)::integer=r.id
                WHERE p.fields_id=false
                    AND (p.company_id=1 OR p.company_id IS NULL)
                    AND (p.res_id IN ('res.users,1') OR p.res_id IS NULL)
                ORDER BY p.company_id NULLS FIRST
            
ERROR: operator does not exist: integer = boolean
LINE 5:                 WHERE p.fields_id=false
                                         ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
 
2022-06-07 11:27:20,625 1 ERROR devel odoo.sql_db: bad query: UPDATE "donation_donation" SET "number"='New' WHERE "number" IS NULL
ERROR: current transaction is aborted, commands ignored until end of transaction block
 
2022-06-07 11:27:20,638 1 WARNING devel odoo.modules.loading: Transient module states were reset 
2022-06-07 11:27:20,641 1 ERROR devel odoo.modules.registry: Failed to load registry 
2022-06-07 11:27:20,641 1 CRITICAL devel odoo.service.server: Failed to initialize database `devel`. 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/service/server.py", line 1201, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 455, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 347, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 199, in load_module_graph
    registry.init_models(cr, model_names, {'module': package.name}, new_install)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 405, in init_models
    model._auto_init()
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 2605, in _auto_init
    new = field.update_db(self, columns)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 812, in update_db
    self.update_db_notnull(model, column)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 868, in update_db_notnull
    model._init_column(self.name)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 2538, in _init_column
    self._cr.execute(query, (value,))
  File "<decorator-gen-3>", line 2, in execute
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 101, in check
    return f(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 298, in execute
    res = self._obj.execute(query, params)

```
The problem is using a `company_dependant` field not declared yet on the default. Solution, declare it on the migration script (I created it then droped the column.

@alexis-via 