### PR TITLE
[14.0] donation: always write donation number on journal entry

### DIFF
--- a/donation/models/donation.py
+++ b/donation/models/donation.py
@@ -301,6 +301,7 @@ class DonationDonation(models.Model):
             "partner_id": self.commercial_partner_id.id,
             "currency_id": self.currency_id.id,
             "amount_currency": total_currency,
+            "name": self.number,
         }
         return vals
 
@@ -347,7 +348,7 @@ class DonationDonation(models.Model):
             "company_id": self.company_id.id,
             "journal_id": journal.id,
             "date": self.donation_date,
-            "ref": self.payment_ref or self.number,
+            "ref": self.payment_ref,
             "line_ids": [],
         }
 
@@ -375,6 +376,7 @@ class DonationDonation(models.Model):
                         "partner_id": self.commercial_partner_id.id,
                         "currency_id": self.currency_id.id,
                         "amount_currency": -amount,
+                        "name": self.number,
                     },
                 )
             )
@@ -580,7 +582,7 @@ class DonationDonation(models.Model):
                 )
             if donation.move_id:
                 donation.move_id.button_cancel()
-                donation.move_id.unlink()
+                donation.with_context(force_delete=True).move_id.unlink()
             donation.write({"state": "cancel"})
             donation.partner_id._update_donor_rank()
 

--- a/donation/tests/test_donation.py
+++ b/donation/tests/test_donation.py
@@ -162,9 +162,8 @@ class TestDonation(TransactionCase):
                 self.assertFalse(donation.move_id)
             else:
                 self.assertEqual(donation.move_id.state, "posted")
-                self.assertEqual(
-                    donation.payment_ref or donation.number, donation.move_id.ref
-                )
+                self.assertEqual(donation.payment_ref, donation.move_id.ref)
+                self.assertEqual(donation.number, donation.move_id.line_ids[0].name)
                 self.assertEqual(
                     donation.payment_mode_id.fixed_journal_id,
                     donation.move_id.journal_id,


### PR DESCRIPTION
Always write donation number on journal entry:
- before this PR: on 'ref' of account.move Odoo would write "donation.payment_ref or donation.number"
- after this PR: donation.payment_ref is written on 'ref' of account.move. donation.number is written on 'name' of account.move.line

Add force_delete=True in context to allow cancelling a donation without fiscal receipt