### PR TITLE
[14.0][FIX] donation by direct debit

### DIFF
--- a/donation/models/account_journal.py
+++ b/donation/models/account_journal.py
@@ -2,7 +2,8 @@
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class AccountJournal(models.Model):
@@ -16,8 +17,65 @@ class AccountJournal(models.Model):
         domain="[('reconcile', '=', True), ('deprecated', '=', False), "
         "('company_id', '=', company_id), "
         "('id', 'not in', (default_account_id, suspense_account_id, "
-        "payment_credit_account_id, payment_debit_account_id))]",
+        "payment_credit_account_id, payment_debit_account_id, "
+        "donation_debit_order_account_id))]",
         string="Donation by Credit Transfer Account",
         help="Transfer account for donations received by credit transfer. "
         "Leave empty if you don't receive donations on this bank account.",
     )
+    donation_debit_order_account_id = fields.Many2one(
+        "account.account",
+        check_company=True,
+        copy=False,
+        ondelete="restrict",
+        domain="[('reconcile', '=', True), ('deprecated', '=', False), "
+        "('company_id', '=', company_id), "
+        "('user_type_id.type', '=', 'receivable'), "
+        "('id', 'not in', (default_account_id, suspense_account_id, "
+        "payment_credit_account_id, payment_debit_account_id, donation_account_id))]",
+        string="Donation by Debit Order Account",
+        help="Transfer account for donations by debit order. "
+        "Leave empty if you don't handle donations by debit order on this bank account."
+        "This account must be a receivable account, otherwise the debit order will not work.",
+    )
+
+    @api.constrains("donation_account_id", "donation_debit_order_account_id")
+    def _check_donation_accounts(self):
+        for journal in self:
+            if (
+                journal.donation_account_id
+                and not journal.donation_account_id.reconcile
+            ):
+                raise ValidationError(
+                    _(
+                        "The Donation by Credit Transfer Account of journal "
+                        "'%(journal)s' must be reconciliable, but the account "
+                        "'%(account)s' is not reconciliable.",
+                        journal=journal.display_name,
+                        account=journal.donation_account_id.display_name,
+                    )
+                )
+            ddo_account = journal.donation_debit_order_account_id
+            if ddo_account:
+                if not ddo_account.reconcile:
+                    raise ValidationError(
+                        _(
+                            "The Donation by Debit Order Account of journal "
+                            "'%(journal)s' must be reconciliable, but the account "
+                            "'%(account)s' is not reconciliable.",
+                            journal=journal.display_name,
+                            account=ddo_account.display_name,
+                        )
+                    )
+                if ddo_account.user_type_id.type != "receivable":
+                    raise ValidationError(
+                        _(
+                            "The Donation by Debit Order Account of journal "
+                            "'%(journal)s' must be a receivable account, "
+                            "but the account '%(account)s' is configured with "
+                            "type '%(account_type)s'.",
+                            journal=journal.display_name,
+                            account=ddo_account.display_name,
+                            account_type=ddo_account.user_type_id.display_name,
+                        )
+                    )

--- a/donation/views/account_journal.xml
+++ b/donation/views/account_journal.xml
@@ -12,6 +12,10 @@
                     name="donation_account_id"
                     attrs="{'invisible': [('type', '!=', 'bank')]}"
                 />
+            <field
+                    name="donation_debit_order_account_id"
+                    attrs="{'invisible': [('type', '!=', 'bank')]}"
+                />
         </field>
     </field>
 </record>

--- a/donation_direct_debit/models/donation.py
+++ b/donation_direct_debit/models/donation.py
@@ -88,11 +88,11 @@ class DonationDonation(models.Model):
                         "data-oe-id=%d>%s</a> has been automatically created"
                     ) % (payorder.id, payorder.name)
                 # add payment line
-                payment_account_id = (
-                    donation.payment_mode_id.fixed_journal_id.payment_debit_account_id.id
+                match_account_id = (
+                    donation.payment_mode_id.fixed_journal_id.donation_debit_order_account_id.id
                 )
                 for mline in donation.move_id.line_ids:
-                    if mline.account_id.id == payment_account_id:
+                    if mline.account_id.id == match_account_id:
                         mline.sudo().create_payment_line_from_move_line(payorder)
                         break
                 if not msg:


### PR DESCRIPTION
For donation by debit order, we can't use twice the account "payment_debit_account_id", when validating the donation AND when validation the debit order. We have to use a different account. And, now that the OCA module account_payment_order uses account.payment, this account must be a receivable account.

Add checks on account.journal.