### PR TITLE
[14.0][FIX] Move code from donation to donation_direct_debit

### DIFF
--- a/donation/models/account_journal.py
+++ b/donation/models/account_journal.py
@@ -17,29 +17,13 @@ class AccountJournal(models.Model):
         domain="[('reconcile', '=', True), ('deprecated', '=', False), "
         "('company_id', '=', company_id), "
         "('id', 'not in', (default_account_id, suspense_account_id, "
-        "payment_credit_account_id, payment_debit_account_id, "
-        "donation_debit_order_account_id))]",
+        "payment_credit_account_id, payment_debit_account_id))]",
         string="Donation by Credit Transfer Account",
         help="Transfer account for donations received by credit transfer. "
         "Leave empty if you don't receive donations on this bank account.",
     )
-    donation_debit_order_account_id = fields.Many2one(
-        "account.account",
-        check_company=True,
-        copy=False,
-        ondelete="restrict",
-        domain="[('reconcile', '=', True), ('deprecated', '=', False), "
-        "('company_id', '=', company_id), "
-        "('user_type_id.type', '=', 'receivable'), "
-        "('id', 'not in', (default_account_id, suspense_account_id, "
-        "payment_credit_account_id, payment_debit_account_id, donation_account_id))]",
-        string="Donation by Debit Order Account",
-        help="Transfer account for donations by debit order. "
-        "Leave empty if you don't handle donations by debit order on this bank account."
-        "This account must be a receivable account, otherwise the debit order will not work.",
-    )
 
-    @api.constrains("donation_account_id", "donation_debit_order_account_id")
+    @api.constrains("donation_account_id")
     def _check_donation_accounts(self):
         for journal in self:
             if (
@@ -55,27 +39,3 @@ class AccountJournal(models.Model):
                         account=journal.donation_account_id.display_name,
                     )
                 )
-            ddo_account = journal.donation_debit_order_account_id
-            if ddo_account:
-                if not ddo_account.reconcile:
-                    raise ValidationError(
-                        _(
-                            "The Donation by Debit Order Account of journal "
-                            "'%(journal)s' must be reconciliable, but the account "
-                            "'%(account)s' is not reconciliable.",
-                            journal=journal.display_name,
-                            account=ddo_account.display_name,
-                        )
-                    )
-                if ddo_account.user_type_id.type != "receivable":
-                    raise ValidationError(
-                        _(
-                            "The Donation by Debit Order Account of journal "
-                            "'%(journal)s' must be a receivable account, "
-                            "but the account '%(account)s' is configured with "
-                            "type '%(account_type)s'.",
-                            journal=journal.display_name,
-                            account=ddo_account.display_name,
-                            account_type=ddo_account.user_type_id.display_name,
-                        )
-                    )

--- a/donation/models/donation.py
+++ b/donation/models/donation.py
@@ -289,13 +289,6 @@ class DonationDonation(models.Model):
             debit = 0
         if self.bank_statement_line_id:
             account_id = journal.donation_account_id.id
-        elif self.payment_mode_id.payment_order_ok:
-            if not journal.donation_debit_order_account_id:
-                raise UserError(
-                    _("Missing Donation by Debit Order Account on journal '%s'.")
-                    % journal.display_name
-                )
-            account_id = journal.donation_debit_order_account_id.id
         else:
             if not journal.payment_debit_account_id:
                 raise UserError(

--- a/donation_direct_debit/__manifest__.py
+++ b/donation_direct_debit/__manifest__.py
@@ -15,6 +15,7 @@
     "depends": ["account_banking_sepa_direct_debit", "donation"],
     "data": [
         "views/donation.xml",
+        "views/account_journal.xml",
     ],
     "demo": ["demo/donation_demo.xml"],
     "installable": True,

--- a/donation_direct_debit/models/__init__.py
+++ b/donation_direct_debit/models/__init__.py
@@ -1,1 +1,2 @@
 from . import donation
+from . import account_journal

--- a/donation_direct_debit/models/account_journal.py
+++ b/donation_direct_debit/models/account_journal.py
@@ -1,0 +1,54 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    donation_debit_order_account_id = fields.Many2one(
+        "account.account",
+        check_company=True,
+        copy=False,
+        ondelete="restrict",
+        domain="[('reconcile', '=', True), ('deprecated', '=', False), "
+        "('company_id', '=', company_id), "
+        "('user_type_id.type', '=', 'receivable'), "
+        "('id', 'not in', (default_account_id, suspense_account_id, "
+        "payment_credit_account_id, payment_debit_account_id, donation_account_id))]",
+        string="Donation by Debit Order Account",
+        help="Transfer account for donations by debit order. "
+        "Leave empty if you don't handle donations by debit order on this bank account."
+        "This account must be a receivable account, otherwise the debit order will not work.",
+    )
+
+    @api.constrains("donation_debit_order_account_id")
+    def _check_donation_accounts(self):
+        for journal in self:
+            ddo_account = journal.donation_debit_order_account_id
+            if ddo_account:
+                if not ddo_account.reconcile:
+                    raise ValidationError(
+                        _(
+                            "The Donation by Debit Order Account of journal "
+                            "'%(journal)s' must be reconciliable, but the account "
+                            "'%(account)s' is not reconciliable.",
+                            journal=journal.display_name,
+                            account=ddo_account.display_name,
+                        )
+                    )
+                if ddo_account.user_type_id.type != "receivable":
+                    raise ValidationError(
+                        _(
+                            "The Donation by Debit Order Account of journal "
+                            "'%(journal)s' must be a receivable account, "
+                            "but the account '%(account)s' is configured with "
+                            "type '%(account_type)s'.",
+                            journal=journal.display_name,
+                            account=ddo_account.display_name,
+                            account_type=ddo_account.user_type_id.display_name,
+                        )
+                    )

--- a/donation_direct_debit/models/donation.py
+++ b/donation_direct_debit/models/donation.py
@@ -57,6 +57,22 @@ class DonationDonation(models.Model):
         vals = {"payment_mode_id": self.payment_mode_id.id}
         return vals
 
+    def _prepare_counterpart_move_line(
+        self, total_company_cur, total_currency, journal
+    ):
+        vals = super()._prepare_counterpart_move_line(
+            total_company_cur, total_currency, journal
+        )
+        journal = self.payment_mode_id.fixed_journal_id
+        if not self.bank_statement_line_id and self.payment_mode_id.payment_order_ok:
+            if not journal.donation_debit_order_account_id:
+                raise UserError(
+                    _("Missing Donation by Debit Order Account on journal '%s'.")
+                    % journal.display_name
+                )
+            vals["account_id"] = journal.donation_debit_order_account_id.id
+        return vals
+
     def validate(self):
         """Create Direct debit payment order on donation validation or update
         an existing draft Direct Debit pay order"""

--- a/donation_direct_debit/views/account_journal.xml
+++ b/donation_direct_debit/views/account_journal.xml
@@ -3,13 +3,12 @@
 
 
 <record id="view_account_journal_form" model="ir.ui.view">
-    <field name="name">donation.account.journal.form</field>
     <field name="model">account.journal</field>
-    <field name="inherit_id" ref="account.view_account_journal_form" />
+    <field name="inherit_id" ref="donation.view_account_journal_form" />
     <field name="arch" type="xml">
-        <field name="payment_debit_account_id" position="after">
+        <field name="donation_account_id" position="after">
             <field
-                    name="donation_account_id"
+                    name="donation_debit_order_account_id"
                     attrs="{'invisible': [('type', '!=', 'bank')]}"
                 />
         </field>


### PR DESCRIPTION
The field payment_order_ok on payment modes is part of account_payment_order, but the donation module doesn't depend on it (and it should not). So the corresponding code has been moved to donation_direct_debit.