### PR TITLE
[14.0][IMP] donation: partner form view usability improvement

### DIFF
--- a/donation/views/res_partner.xml
+++ b/donation/views/res_partner.xml
@@ -14,10 +14,13 @@
     <record id="view_partner_form" model="ir.ui.view">
         <field name="name">donation.button.res.partner.form</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="inherit_id" ref="donation_base.view_partner_property_form" />
         <field name="groups_id" eval="[(4, ref('donation.group_donation_viewer'))]" />
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='button_box']" position="inside">
+            <button
+                name="%(donation_base.partner_tax_receipt_action)d"
+                position="before"
+            >
                 <button
                     class="oe_stat_button"
                     type="action"
@@ -26,7 +29,7 @@
                 >
                     <field string="Donations" name="donation_count" widget="statinfo" />
                 </button>
-            </xpath>
+            </button>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
On res.partner form view, place the button for donations next to the button for fiscal receipts

![shot](https://github.com/OCA/donation/assets/1157917/b2d9e96a-0a98-4da9-9c2e-7deb79c8100c)
