### PR TITLE
[14.0] donation: remove full ACL on account.move and account.move.line

### DIFF
--- a/donation/models/donation.py
+++ b/donation/models/donation.py
@@ -463,8 +463,8 @@ class DonationDonation(models.Model):
                 move_vals = donation._prepare_donation_move()
                 # when we have a full in-kind donation: no account move
                 if move_vals:
-                    move = self.env["account.move"].create(move_vals)
-                    move.action_post()
+                    move = self.env["account.move"].sudo().create(move_vals)
+                    move.sudo().action_post()
                     vals["move_id"] = move.id
             else:
                 donation.message_post(
@@ -477,7 +477,7 @@ class DonationDonation(models.Model):
 
             donation.write(vals)
             if donation.bank_statement_line_id:
-                donation._reconcile_donation_from_bank_statement()
+                donation.sudo()._reconcile_donation_from_bank_statement()
             donation.partner_id._update_donor_rank()
         return
 
@@ -583,8 +583,8 @@ class DonationDonation(models.Model):
                     % donation.tax_receipt_id.number
                 )
             if donation.move_id:
-                donation.move_id.button_cancel()
-                donation.with_context(force_delete=True).move_id.unlink()
+                donation.move_id.sudo().button_cancel()
+                donation.with_context(force_delete=True).sudo().move_id.unlink()
             donation.write({"state": "cancel"})
             donation.partner_id._update_donor_rank()
 

--- a/donation/security/ir.model.access.csv
+++ b/donation/security/ir.model.access.csv
@@ -8,9 +8,6 @@ access_donation_line_user,Full access on donation.line to Donation User,model_do
 access_donation_donation_read,Read access on donation.donation to Employee grp,model_donation_donation,base.group_user,1,0,0,0
 access_donation_line_read,Read access on donation.line to Employee grp,model_donation_line,base.group_user,1,0,0,0
 access_account_journal_donation,Read access on account.journal,account.model_account_journal,group_donation_viewer,1,0,0,0
-access_account_move_donation,Full access on account.move,account.model_account_move,group_donation_user,1,1,1,1
-access_account_move_line_donation,Full access on account.move.line,account.model_account_move_line,group_donation_user,1,1,1,1
-access_account_analytic_line_donation,Full access on account.analytic.line to donation user,analytic.model_account_analytic_line,group_donation_user,1,1,1,1
 access_donation_report,Full access on donation.report to Donation Viewer,model_donation_report,group_donation_viewer,1,1,1,1
 access_donation_tax_receipt_viewer,Read access on donation.tax.receipt to Donation Viewer grp,model_donation_tax_receipt,donation.group_donation_viewer,1,0,0,0
 access_donation_tax_receipt,Create access on donation.tax.receipt to Donation User,model_donation_tax_receipt,donation.group_donation_user,1,0,1,0

--- a/donation/views/donation.xml
+++ b/donation/views/donation.xml
@@ -122,8 +122,14 @@
                         <page string="Other Information" name="other">
                             <group name="other">
                             <group name="other-left">
-                                <field name="move_id" />
-                                <field name="bank_statement_line_id" />
+                                <field
+                                        name="move_id"
+                                        groups="account.group_account_user"
+                                    />
+                                <field
+                                        name="bank_statement_line_id"
+                                        groups="account.group_account_user"
+                                    />
                                 <field
                                         name="amount_total_company_currency"
                                         groups="base.group_multi_currency"


### PR DESCRIPTION
It's not a good idea to have a read/write/create/unlink ACL on account.move and account.move.line to donation user => we remove that and add sudo() when needed.