### PR TITLE
[16.0][FIX] remove nested loop in tax reports

### DIFF
--- a/donation_base/report/report_donationtax.xml
+++ b/donation_base/report/report_donationtax.xml
@@ -9,27 +9,25 @@
     <!-- This is just a very basic tax receipt report
     You should customize the style and layout in a custom module -->
     <template id="donation_base.report_donationtaxreceipt_document">
-        <t t-foreach="docs" t-as="o">
-            <t t-call="web.internal_layout">
-                <div class="page">
-                    <h1>Donation Tax Receipt <span t-field="o.number" /></h1>
-                    <h3>Donor:</h3>
-                    <div
-                        t-field="o.partner_id"
-                        t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
-                    />
-                    <h3>Date: <span t-field="o.date" /></h3>
-                    <h3>Amount Total: <span t-field="o.amount" /></h3>
-                </div>
-            </t>
+        <t t-call="web.internal_layout">
+            <div class="page">
+                <h1>Donation Tax Receipt <span t-field="o.number" /></h1>
+                <h3>Donor:</h3>
+                <div
+                    t-field="o.partner_id"
+                    t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
+                />
+                <h3>Date: <span t-field="o.date" /></h3>
+                <h3>Amount Total: <span t-field="o.amount" /></h3>
+            </div>
         </t>
     </template>
     <template id="report_donationtaxreceipt">
         <t t-call="web.html_container">
-            <t t-foreach="docs" t-as="doc">
+            <t t-foreach="docs" t-as="o">
                 <t
                     t-call="donation_base.report_donationtaxreceipt_document"
-                    t-lang="doc.partner_id.lang"
+                    t-lang="o.partner_id.lang"
                 />
             </t>
         </t>


### PR DESCRIPTION
remove the nested loop in the donation tax report template to ensure that each record is present once in the generated report instead of the number of records squared when generating a report for multiple records.