### PR TITLE
[IMP] donation_base: compute is_donation

### DIFF
--- a/donation_base/models/product.py
+++ b/donation_base/models/product.py
@@ -10,6 +10,7 @@ from odoo.exceptions import ValidationError
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
+    is_donation = fields.Boolean(compute="_compute_is_donation", store=True)
     detailed_type = fields.Selection(
         selection_add=[
             ("donation", "Donation"),
@@ -31,6 +32,11 @@ class ProductTemplate(models.Model):
         precompute=True,
         help="Specify if the product is eligible for a tax receipt",
     )
+
+    @api.depends("detailed_type")
+    def _compute_is_donation(self):
+        for product in self:
+            product.is_donation = product.detailed_type.startswith("donation")
 
     @api.depends("detailed_type")
     def _compute_tax_receipt_ok(self):

--- a/donation_base/views/product.xml
+++ b/donation_base/views/product.xml
@@ -15,7 +15,7 @@
                 <filter
                     name="filter_donation"
                     string="Donation"
-                    domain="[('detailed_type', 'in', ('donation', 'donation_in_kind_consu', 'donation_in_kind_service'))]"
+                    domain="[('is_donation', '=', True)]"
                 />
             </filter>
             <filter name="filter_to_purchase" position="after">
@@ -33,10 +33,10 @@
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
             <field name="detailed_type" position="after">
-                <!-- unfortunately, Odoo doesn't accept 'not like' in attrs -->
+                <field name="is_donation" invisible="1" />
                 <field
                     name="tax_receipt_ok"
-                    attrs="{'invisible': [('detailed_type', 'not in', ('donation', 'donation_in_kind_service', 'donation_in_kind_consu'))]}"
+                    attrs="{'invisible': [('is_donation', '=', False)]}"
                 />
             </field>
         </field>


### PR DESCRIPTION
Add a new field 'is_donation' so that we can easily filter which products are donation and which are not without listing all the values for 'detailed_type'.

This allow to simplify the code, and to easily adds detailed_type for other donation type in other modules.