### PR TITLE
[16.0][UPG] Annual receipt per partner and payment mode

### DIFF
--- a/donation/models/donation.py
+++ b/donation/models/donation.py
@@ -447,6 +447,18 @@ class DonationDonation(models.Model):
                     )
                     % donation.display_name
                 )
+            
+            mixed_in_kind = any([line.in_kind for line in donation.line_ids]) and any(
+                [not line.in_kind for line in donation.line_ids]
+            )
+            if mixed_in_kind:
+                raise UserError(
+                    _(
+                        "Donation %s has a mix of in-kind and non in-kind "
+                        "donation lines. Please separate them into two donations."
+                    )
+                    % donation.display_name
+                )
 
             vals = {"state": "done"}
             if full_in_kind and donation.payment_mode_id:

--- a/donation/models/donation_tax_receipt.py
+++ b/donation/models/donation_tax_receipt.py
@@ -15,7 +15,7 @@ class DonationTaxReceipt(models.Model):
 
     @api.model
     def update_tax_receipt_annual_dict(
-        self, tax_receipt_annual_dict, start_date, end_date, company
+        self, tax_receipt_annual_dict, start_date, end_date, company, split_payment_method=False
     ):
         res = super().update_tax_receipt_annual_dict(
             tax_receipt_annual_dict, start_date, end_date, company
@@ -36,15 +36,22 @@ class DonationTaxReceipt(models.Model):
             tax_receipt_amount = donation.tax_receipt_total
             if company.currency_id.is_zero(tax_receipt_amount):
                 continue
-            partner = donation.commercial_partner_id
-            if partner not in tax_receipt_annual_dict:
-                tax_receipt_annual_dict[partner] = {
+            partner = donation.commercial_partner_id            
+            payment_mode = donation.payment_mode_id
+
+            if split_payment_method:
+                key = (partner,payment_mode) 
+            else:
+                key = (partner,)
+                
+            if key not in tax_receipt_annual_dict:
+                tax_receipt_annual_dict[key] = {
                     "amount": tax_receipt_amount,
                     "extra_vals": {"donation_ids": [(6, 0, [donation.id])]},
                 }
             else:
-                tax_receipt_annual_dict[partner]["amount"] += tax_receipt_amount
-                tax_receipt_annual_dict[partner]["extra_vals"]["donation_ids"][0][
+                tax_receipt_annual_dict[key]["amount"] += tax_receipt_amount
+                tax_receipt_annual_dict[key]["extra_vals"]["donation_ids"][0][
                     2
                 ].append(donation.id)
         return res

--- a/donation/wizard/res_config_settings.xml
+++ b/donation/wizard/res_config_settings.xml
@@ -46,7 +46,7 @@
                                 />
                             </div>
                         </div>
-                       <div
+                        <div
                             class="col-12 col-lg-6 o_setting_box"
                             id="donation_check_total"
                         >
@@ -55,6 +55,14 @@
                             </div>
                             <div class="o_setting_right_pane">
                                 <label for="group_donation_check_total" />
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box" id="split_receipts_payment_mode">
+                            <div class="o_setting_left_pane">
+                                    <field name="split_by_payment_mode" />
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="split_by_payment_mode" />
                             </div>
                         </div>
                     </div>

--- a/donation_base/models/__init__.py
+++ b/donation_base/models/__init__.py
@@ -1,3 +1,5 @@
 from . import product
 from . import res_partner
 from . import donation_tax_receipt
+from . import res_config_settings
+from . import res_company

--- a/donation_base/models/donation_tax_receipt.py
+++ b/donation_base/models/donation_tax_receipt.py
@@ -52,6 +52,11 @@ class DonationTaxReceipt(models.Model):
         required=True,
         tracking=True,
     )
+    payment_mode_id = fields.Many2one(
+        "account.payment.mode",
+        string="Payment Mode",
+        tracking=True,
+    )
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -67,7 +72,7 @@ class DonationTaxReceipt(models.Model):
 
     @api.model
     def update_tax_receipt_annual_dict(
-        self, tax_receipt_annual_dict, start_date, end_date, company
+        self, tax_receipt_annual_dict, start_date, end_date, company, split_payment_method=False
     ):
         """This method is inherited in donation and donation_sale
         It is called by the tax.receipt.annual.create wizard"""

--- a/donation_base/models/res_company.py
+++ b/donation_base/models/res_company.py
@@ -1,0 +1,15 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    donation_receipt_split_by_payment_mode = fields.Boolean(
+        string="Split Donation Receipts by Payment Mode",
+        help="If enabled, annual donation tax receipts will be split by payment mode. "
+        "If disabled, one annual donation tax receipt will be generated per donor, "
+        "regardless of the payment mode used.",
+    )

--- a/donation_base/models/res_config_settings.py
+++ b/donation_base/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, fields, models, _
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    split_by_payment_mode = fields.Boolean(
+        string="Split Donation Receipts by Payment Mode",
+        related="company_id.donation_receipt_split_by_payment_mode",
+        readonly=False)

--- a/donation_base/views/donation_tax_receipt.xml
+++ b/donation_base/views/donation_tax_receipt.xml
@@ -40,6 +40,7 @@
                         <field name="print_date" />
                         <field name="currency_id" invisible="1" />
                         <field name="amount" />
+                        <field name="payment_mode_id"/>
                         <field name="company_id" groups="base.group_multi_company" />
                     </group>
                 </sheet>

--- a/donation_base/wizard/tax_receipt_annual_create.py
+++ b/donation_base/wizard/tax_receipt_annual_create.py
@@ -37,16 +37,18 @@ class TaxReceiptAnnualCreate(models.TransientModel):
     )
 
     @api.model
-    def _prepare_annual_tax_receipt(self, partner, partner_dict):
+    def _prepare_annual_tax_receipt(self, key_table, partner_dict, split_payment_method=False):
         vals = {
             "company_id": self.company_id.id,
             "currency_id": self.company_id.currency_id.id,
             "amount": partner_dict["amount"],
             "type": "annual",
-            "partner_id": partner.id,
+            "partner_id": key_table[0].id,
             "date": self.end_date,
             "donation_date": self.end_date,
         }
+        if split_payment_method:
+            vals["payment_mode_id"] = key_table[1].id
         # designed to add add O2M fields donation_ids and invoice_ids
         vals.update(partner_dict["extra_vals"])
         return vals
@@ -58,10 +60,11 @@ class TaxReceiptAnnualCreate(models.TransientModel):
             self.start_date,
             self.end_date,
         )
+        split_by_payment_mode = self.company_id.donation_receipt_split_by_payment_mode
         dtro = self.env["donation.tax.receipt"]
         tax_receipt_annual_dict = {}
         self.env["donation.tax.receipt"].update_tax_receipt_annual_dict(
-            tax_receipt_annual_dict, self.start_date, self.end_date, self.company_id
+            tax_receipt_annual_dict, self.start_date, self.end_date, self.company_id, split_payment_method=split_by_payment_mode
         )
         tax_receipt_ids = []
         existing_annual_receipts = dtro.search(
@@ -74,22 +77,26 @@ class TaxReceiptAnnualCreate(models.TransientModel):
         )
         existing_annual_receipts_dict = {}
         for receipt in existing_annual_receipts:
-            existing_annual_receipts_dict[receipt.partner_id] = receipt
+            if split_by_payment_mode and receipt.payment_mode_id:
+                key = (receipt.partner_id, receipt.payment_mode_id.id)
+            else:
+                key = (receipt.partner_id,)
+            existing_annual_receipts_dict[key] = receipt
 
-        for partner, partner_dict in tax_receipt_annual_dict.items():
+        for key_table, partner_dict in tax_receipt_annual_dict.items():
             # Block if the partner already has an annual tax receipt
-            if partner in existing_annual_receipts_dict:
-                existing_receipt = existing_annual_receipts_dict[partner]
+            if key_table in existing_annual_receipts_dict:
+                existing_receipt = existing_annual_receipts_dict[key_table]
                 raise UserError(
                     _(
                         "The Donor '%(partner)s' already has an annual tax receipt "
                         "in this timeframe: %(receipt)s dated %(number)s.",
-                        partner=partner.display_name,
+                        partner=key_table[0].display_name,
                         receipt=existing_receipt.number,
                         date=format_date(self.env, existing_receipt.date),
                     )
                 )
-            vals = self._prepare_annual_tax_receipt(partner, partner_dict)
+            vals = self._prepare_annual_tax_receipt(key_table, partner_dict, split_payment_method=split_by_payment_mode)
             tax_receipt = dtro.create(vals)
             tax_receipt_ids.append(tax_receipt.id)
             logger.info("Tax receipt %s generated", tax_receipt.number)


### PR DESCRIPTION
[WIP] I still need (in order to complete his PR) to have some insight, specially regarding the reason behind the separation in two modules donation_base and donation. Thank for your help !

Two upgrade propositions in this PR : 

1. Add a usererror on donation validation if it contains both in kind and monetary donation.
2. Add the company configuration allowing to generate annual receipts per partner and payment mode. In my situation, it is usefull for generating french official receipt report that mentions the payment mode.