### PR TITLE
i18n: complete DE+FR translations for donation_base and donation

### DIFF
--- a/donation/i18n/de.po
+++ b/donation/i18n/de.po
@@ -4,103 +4,71 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2019-01-26 15:41+0000\n"
-"Last-Translator: kempleton <kimdoelling@gmail.com>\n"
-"Language-Team: none\n"
+"POT-Creation-Date: 2025-01-01 00:00+0000\n"
+"PO-Revision-Date: 2026-03-16 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: German\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.3\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_partner__donation_count
 #: model:ir.model.fields,field_description:donation.field_res_users__donation_count
 msgid "# of Donations"
-msgstr "# an Spenden"
+msgstr "Anzahl Spenden"
 
 #. module: donation
 #: model:ir.actions.report,print_report_name:donation.report_thanks
 msgid ""
-"'donation_thanks-%s%s' % (object.number, object.state == 'draft' and '-"
-"draft' or '')"
+"'donation_thanks-%s%s' % (object.number, object.state == 'draft' and "
+"'-draft' or '')"
 msgstr ""
 
 #. module: donation
 #: model:ir.model.constraint,message:donation.constraint_donation_campaign_code_company_uniq
 msgid "A campaign with the same code already exists!"
-msgstr ""
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid "A cancelled donation should not be linked to a tax receipt"
-msgstr ""
-"Eine abgebrochene Spende sollte nicht mit einer Spendenbescheinigung "
-"verknüpft sein"
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid "A cancelled donation should not be linked to an account move"
-msgstr ""
-"Abgebrochene Spenden sollten nicht mit einer Kontobewegung verknüpft sein"
+msgstr "Eine Kampagne mit demselben Code existiert bereits!"
 
 #. module: donation
 #: model:ir.model.constraint,message:donation.constraint_donation_donation_bank_statement_line_uniq
 msgid "A donation already exists for this bank statement line."
-msgstr ""
-
-#. module: donation
-#: model:ir.model.fields,help:donation.field_donation_line__product_detailed_type
-#: model:ir.model.fields,help:donation.field_donation_report__product_detailed_type
-msgid ""
-"A storable product is a product for which you manage stock. The Inventory "
-"app has to be installed.\n"
-"A consumable product is a product for which stock is not managed.\n"
-"A service is a non-material product you provide."
-msgstr ""
-
-#. module: donation
-#: model:ir.model.fields,field_description:donation.field_donation_donation__move_id
-msgid "Account Move"
-msgstr "Kontobewegung"
+msgstr "Für diese Kontoauszugszeile existiert bereits eine Spende."
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_needaction
 msgid "Action Needed"
-msgstr ""
+msgstr "Handlungsbedarf"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__active
 #: model:ir.model.fields,field_description:donation.field_donation_thanks_template__active
 msgid "Active"
-msgstr ""
+msgstr "Aktiv"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_ids
 msgid "Activities"
-msgstr ""
+msgstr "Aktivitäten"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_exception_decoration
 msgid "Activity Exception Decoration"
-msgstr ""
+msgstr "Aktivitätsausnahme-Markierung"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_state
 msgid "Activity State"
-msgstr ""
+msgstr "Aktivitätsstatus"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_type_icon
 msgid "Activity Type Icon"
-msgstr ""
+msgstr "Aktivitätstyp-Symbol"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__amount
@@ -125,23 +93,18 @@ msgstr "Betrag in Unternehmenswährung"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__analytic_distribution
-msgid "Analytic"
-msgstr ""
-
-#. module: donation
-#: model:ir.model.fields,field_description:donation.field_donation_line__analytic_distribution_search
-msgid "Analytic Distribution Search"
-msgstr ""
+msgid "Analytic Distribution"
+msgstr "Analytische Verteilung"
 
 #. module: donation
 #: model:ir.model,name:donation.model_account_analytic_applicability
 msgid "Analytic Plan's Applicabilities"
-msgstr ""
+msgstr "Anwendbarkeit des Analyseplans"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__analytic_precision
 msgid "Analytic Precision"
-msgstr ""
+msgstr "Analytische Genauigkeit"
 
 #. module: donation
 #: model:ir.model.fields.selection,name:donation.selection__donation_donation__tax_receipt_option__annual
@@ -155,12 +118,12 @@ msgstr "Sammelspendenbescheinigung"
 #: model_terms:ir.ui.view,arch_db:donation.donation_thanks_template_form
 #: model_terms:ir.ui.view,arch_db:donation.donation_thanks_template_search
 msgid "Archived"
-msgstr ""
+msgstr "Archiviert"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_attachment_count
 msgid "Attachment Count"
-msgstr ""
+msgstr "Anzahl Anhänge"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
@@ -170,7 +133,7 @@ msgstr "Zurücksetzen auf Entwurf"
 #. module: donation
 #: model:ir.model,name:donation.model_account_bank_statement_line
 msgid "Bank Statement Line"
-msgstr ""
+msgstr "Kontoauszugszeile"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
@@ -195,8 +158,30 @@ msgstr "Abgebrochen"
 #. odoo-python
 #: code:addons/donation/models/donation.py:0
 #, python-format
-msgid "Cannot validate donation %s because it doesn't have any lines!"
+msgid ""
+"Cancelled donation '%s' is linked to a journal entry. This should never "
+"happen."
 msgstr ""
+"Abgebrochene Spende '%s' ist mit einer Buchung verknüpft. Dies sollte "
+"niemals vorkommen."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid ""
+"Cancelled donation '%s' is linked to a tax receipt. This should never "
+"happen."
+msgstr ""
+"Abgebrochene Spende '%s' ist mit einer Spendenbescheinigung verknüpft. "
+"Dies sollte niemals vorkommen."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid "Cannot validate donation %s because it doesn't have any lines!"
+msgstr "Spende %s kann nicht bestätigt werden, da keine Zeilen vorhanden sind!"
 
 #. module: donation
 #. odoo-python
@@ -204,13 +189,15 @@ msgstr ""
 #, python-format
 msgid "Cannot validate donation %s because it is not in draft state."
 msgstr ""
+"Spende %s kann nicht bestätigt werden, da sie sich nicht im Entwurf-Status "
+"befindet."
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/donation.py:0
 #, python-format
 msgid "Cannot validate donation %s because the total amount is 0!"
-msgstr ""
+msgstr "Spende %s kann nicht bestätigt werden, da der Gesamtbetrag 0 ist!"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_report__product_categ_id
@@ -226,17 +213,22 @@ msgstr "Ändern"
 #: model:ir.actions.act_window,name:donation.donation_tax_receipt_option_switch_action
 #: model_terms:ir.ui.view,arch_db:donation.donation_tax_receipt_option_switch_form
 msgid "Change Tax Receipt Option"
-msgstr "Ändere Spendenbescheinigung"
+msgstr "Spendenbescheinigungs-Option ändern"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__check_total
 msgid "Check Amount"
-msgstr "Überprüfe Betrag"
+msgstr "Kontrollbetrag"
+
+#. module: donation
+#: model_terms:ir.ui.view,arch_db:donation.res_config_settings_donation
+msgid "Check Total"
+msgstr "Gesamtbetrag prüfen"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_config_settings__group_donation_check_total
 msgid "Check Total on Donations"
-msgstr ""
+msgstr "Gesamtbetrag bei Spenden prüfen"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__code
@@ -251,7 +243,7 @@ msgstr "Code für eine Spendenkampagne"
 #. module: donation
 #: model:ir.model,name:donation.model_res_company
 msgid "Companies"
-msgstr ""
+msgstr "Unternehmen"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__company_id
@@ -274,7 +266,7 @@ msgstr "Unternehmenswährung"
 #. module: donation
 #: model:ir.model,name:donation.model_res_config_settings
 msgid "Config Settings"
-msgstr ""
+msgstr "Konfigurationseinstellungen"
 
 #. module: donation
 #: model:ir.ui.menu,name:donation.donation_config_menu
@@ -284,7 +276,7 @@ msgstr "Konfiguration"
 #. module: donation
 #: model:ir.model,name:donation.model_res_partner
 msgid "Contact"
-msgstr ""
+msgstr "Kontakt"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__country_id
@@ -294,14 +286,14 @@ msgstr "Land"
 #. module: donation
 #: model:ir.ui.menu,name:donation.tax_receipt_annual_create_menu
 msgid "Create Annual Receipts"
-msgstr "Erstelle Sammelspendenbescheinigungen"
+msgstr "Sammelspendenbescheinigungen erstellen"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/account_bank_statement_line.py:0
 #, python-format
 msgid "Create Donation from Bank Statement Line"
-msgstr ""
+msgstr "Spende aus Kontoauszugszeile erstellen"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__create_uid
@@ -337,8 +329,8 @@ msgstr "Aktuelle Spendenkampagne"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_users__context_donation_payment_method_line_id
-msgid "Current Donation Payment Mode"
-msgstr ""
+msgid "Current Donation Payment Method"
+msgstr "Aktuelle Spenden-Zahlungsmethode"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
@@ -358,19 +350,24 @@ msgid "Display Name"
 msgstr "Anzeigename"
 
 #. module: donation
+#: model:ir.model.fields,field_description:donation.field_donation_line__distribution_analytic_account_ids
+msgid "Distribution Analytic Account"
+msgstr "Analytische Verteilungskonten"
+
+#. module: donation
 #: model:ir.model.fields,field_description:donation.field_account_analytic_applicability__business_domain
 msgid "Domain"
-msgstr ""
+msgstr "Domäne"
 
 #. module: donation
 #: model:ir.model,name:donation.model_donation_donation
 #: model:ir.model.fields,field_description:donation.field_account_payment_method_line__donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__donation_id
+#: model:ir.model.fields,field_description:donation.field_donation_report__product_donation_type
 #: model:ir.model.fields,field_description:donation.field_donation_tax_receipt_option_switch__donation_id
 #: model:ir.model.fields.selection,name:donation.selection__account_analytic_applicability__business_domain__donation
 #: model:ir.module.category,name:donation.module_category_donation
 #: model:ir.ui.menu,name:donation.donation_top_menu
-#: model_terms:ir.ui.view,arch_db:donation.account_payment_method_line_search
 #: model_terms:ir.ui.view,arch_db:donation.res_config_settings_donation
 msgid "Donation"
 msgstr "Spende"
@@ -381,9 +378,41 @@ msgstr "Spende"
 #, python-format
 msgid ""
 "Donation %(donation)s is linked to a bank statement line, but the Donation "
-"by Credit Transfer Account is not set for company '%(company)s'. This should "
-"never happen."
+"by Credit Transfer Account is not set for company '%(company)s'. This should"
+" never happen."
 msgstr ""
+"Spende %(donation)s ist mit einer Kontoauszugszeile verknüpft, aber das "
+"Spendenkonto für Überweisungen ist für das Unternehmen '%(company)s' nicht "
+"eingerichtet. Dies sollte niemals vorkommen."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid ""
+"Donation '%(donation)s' is linked to the tax receipt %(tax_receipt)s, so you"
+" cannot delete it."
+msgstr ""
+"Die Spende '%(donation)s' ist mit der Spendenbescheinigung %(tax_receipt)s "
+"verknüpft und kann daher nicht gelöscht werden."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid "Donation '%s' is in Done state, so you cannot delete it."
+msgstr ""
+"Die Spende '%s' ist im Status 'Erledigt' und kann daher nicht gelöscht "
+"werden."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid "Donation '%s' is linked to a journal entry, so you cannot delete it."
+msgstr ""
+"Die Spende '%s' ist mit einer Buchung verknüpft und kann daher nicht "
+"gelöscht werden."
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__campaign_id
@@ -400,7 +429,7 @@ msgstr "Spendenkampagnen"
 #. module: donation
 #: model:res.groups,name:donation.group_donation_check_total
 msgid "Donation Check Total"
-msgstr ""
+msgstr "Spenden-Kontrollbetrag"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__donation_date
@@ -413,7 +442,7 @@ msgstr "Spendendatum"
 #: model:ir.model.fields,field_description:donation.field_donation_donation__line_ids
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
 msgid "Donation Lines"
-msgstr "Spendenzeile"
+msgstr "Spendenzeilen"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__number
@@ -423,34 +452,25 @@ msgstr "Spendennummer"
 #. module: donation
 #: model:ir.ui.menu,name:donation.donation_tax_receipt_menu
 msgid "Donation Tax Receipts"
-msgstr "Spendenbescheinigung"
+msgstr "Spendenbescheinigungen"
 
 #. module: donation
 #: model:ir.model,name:donation.model_donation_thanks_template
 msgid "Donation Thanks Letter Template"
-msgstr ""
+msgstr "Vorlage für Spenden-Dankesbrief"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_company__donation_account_id
 #: model:ir.model.fields,field_description:donation.field_res_config_settings__donation_account_id
 msgid "Donation by Credit Transfer Account"
-msgstr ""
+msgstr "Spendenkonto für Überweisungen"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/account_payment_method_line.py:0
 #, python-format
-msgid "Donation payment mode '%s' is not an inbound payment mode."
-msgstr ""
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/account_payment_method_line.py:0
-#, python-format
-msgid ""
-"Donation payment mode '%s' must be configured with 'Link to Bank Account' "
-"set to 'Fixed'."
-msgstr ""
+msgid "Donation payment method '%s'is not an inbound payment method."
+msgstr "Die Spenden-Zahlungsmethode '%s' ist keine Eingangs-Zahlungsmethode."
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_action
@@ -503,7 +523,7 @@ msgstr "Entwurf"
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__tax_receipt_total
 msgid "Eligible Tax Receipt Sub-total in Company Currency"
-msgstr "berechtigte Zwischensumme Spendenbescheinigung"
+msgstr "Berechtigter Spendenbescheinigungs-Teilbetrag in Unternehmenswährung"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_report__tax_receipt_ok
@@ -523,22 +543,22 @@ msgstr "Fehler:"
 #: code:addons/donation/models/donation.py:0
 #, python-format
 msgid "Failed to get account for donation line with product '%s'."
-msgstr ""
+msgstr "Konto für Spendenzeile mit Produkt '%s' konnte nicht ermittelt werden."
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_follower_ids
 msgid "Followers"
-msgstr ""
+msgstr "Follower"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_partner_ids
 msgid "Followers (Partners)"
-msgstr ""
+msgstr "Follower (Partner)"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__activity_type_icon
 msgid "Font awesome icon e.g. fa-tasks"
-msgstr ""
+msgstr "Font-Awesome-Symbol, z.B. fa-tasks"
 
 #. module: donation
 #: model:ir.model.fields.selection,name:donation.selection__donation_donation__tax_receipt_option__each
@@ -550,8 +570,8 @@ msgstr "Für jede Spende"
 #. odoo-python
 #: code:addons/donation/models/donation.py:0
 #, python-format
-msgid "Full in-kind donation: no account move generated"
-msgstr "komplette Sachspende: keine Kontobewegung generiert"
+msgid "Full in-kind donation: no journal entry generated."
+msgstr "Komplette Sachspende: keine Buchung generiert."
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
@@ -562,7 +582,7 @@ msgstr "Gruppieren nach"
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__has_message
 msgid "Has Message"
-msgstr ""
+msgstr "Hat Nachricht"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__id
@@ -578,38 +598,42 @@ msgstr "ID"
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_exception_icon
 msgid "Icon"
-msgstr ""
+msgstr "Symbol"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__activity_exception_icon
 msgid "Icon to indicate an exception activity."
-msgstr ""
+msgstr "Symbol zur Kennzeichnung einer Ausnahmeaktivität."
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__message_needaction
 msgid "If checked, new messages require your attention."
-msgstr ""
+msgstr "Wenn aktiviert, erfordern neue Nachrichten Ihre Aufmerksamkeit."
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__message_has_error
 msgid "If checked, some messages have a delivery error."
-msgstr ""
+msgstr "Wenn aktiviert, haben einige Nachrichten einen Zustellfehler."
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_account_payment_method_line__donation
-msgid "If enabled, this payment mode will be available on donations"
-msgstr ""
+msgid "If enabled, this payment method will be available on donations"
+msgstr "Wenn aktiviert, ist diese Zahlungsmethode für Spenden verfügbar"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_thanks_template__image
 msgid "Image"
-msgstr ""
+msgstr "Bild"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__in_kind
 #: model:ir.model.fields,field_description:donation.field_donation_report__in_kind
-#: model_terms:ir.ui.view,arch_db:donation.donation_report_search
 msgid "In Kind"
+msgstr "Sachspende"
+
+#. module: donation
+#: model_terms:ir.ui.view,arch_db:donation.donation_report_search
+msgid "In kind"
 msgstr "Sachspende"
 
 #. module: donation
@@ -620,18 +644,12 @@ msgstr "Ist geeignet für Spendenbescheinigung"
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_is_follower
 msgid "Is Follower"
-msgstr ""
+msgstr "Ist Follower"
 
 #. module: donation
-#: model:ir.model.fields,field_description:donation.field_donation_campaign____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_donation____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_line____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_report____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_tax_receipt_option_switch____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_thanks_template____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_validate____last_update
-msgid "Last Modified on"
-msgstr "Zuletzt geändert am"
+#: model:ir.model.fields,field_description:donation.field_donation_donation__move_id
+msgid "Journal Entry"
+msgstr "Buchung"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__write_uid
@@ -656,70 +674,57 @@ msgstr "Zuletzt aktualisiert am"
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_from_bank_statement_line_form
 msgid "Lines"
-msgstr ""
-
-#. module: donation
-#: model:ir.model.fields,field_description:donation.field_donation_donation__message_main_attachment_id
-msgid "Main Attachment"
-msgstr ""
+msgstr "Zeilen"
 
 #. module: donation
 #: model:ir.module.category,description:donation.module_category_donation
 msgid "Manage donations"
-msgstr "Verwalte Spenden"
+msgstr "Spenden verwalten"
 
 #. module: donation
 #: model:res.groups,name:donation.group_donation_manager
 msgid "Manager"
-msgstr "Manager"
+msgstr "Verwalter"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_tree
 msgid "Mark all selected donation as Thanks Printed?"
-msgstr ""
+msgstr "Alle ausgewählten Spenden als 'Dank gedruckt' markieren?"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_tree
 msgid "Mark as Thanks Printed"
-msgstr ""
+msgstr "Als 'Dank gedruckt' markieren"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_has_error
 msgid "Message Delivery error"
-msgstr ""
+msgstr "Nachrichtenzustellfehler"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_ids
 msgid "Messages"
-msgstr ""
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid "Missing Outstanding Receipts Account on company '%s'."
-msgstr ""
+msgstr "Nachrichten"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/account_bank_statement_line.py:0
 #, python-format
-msgid "Missing Product for Donations via Credit Transfer for company '%s'."
-msgstr ""
+msgid "Missing Product for Donations via Credit Transfert for company '%s'."
+msgstr "Fehlendes Spendenprodukt für Überweisungen für Unternehmen '%s'."
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/account_bank_statement_line.py:0
 #, python-format
-msgid ""
-"Missing inbound payment mode linked to the bank journal '%s' configured with "
-"'Link to Bank Account' set to 'Fixed'."
+msgid "Missing inbound payment method linked to the bank journal '%s'."
 msgstr ""
+"Fehlende Eingangs-Zahlungsmethode, verknüpft mit dem Bankjournal '%s'."
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__my_activity_date_deadline
 msgid "My Activity Deadline"
-msgstr ""
+msgstr "Meine Aktivitätsfrist"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__name
@@ -730,29 +735,29 @@ msgstr "Name"
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_campaign_search
 msgid "Name or Code"
-msgstr ""
+msgstr "Name oder Code"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/donation.py:0
 #, python-format
 msgid "New"
-msgstr ""
+msgstr "Neu"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_date_deadline
 msgid "Next Activity Deadline"
-msgstr ""
+msgstr "Nächste Aktivitätsfrist"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_summary
 msgid "Next Activity Summary"
-msgstr ""
+msgstr "Zusammenfassung nächste Aktivität"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_type_id
 msgid "Next Activity Type"
-msgstr ""
+msgstr "Nächster Aktivitätstyp"
 
 #. module: donation
 #: model:ir.model.fields.selection,name:donation.selection__donation_donation__tax_receipt_option__none
@@ -767,31 +772,33 @@ msgstr "Notizen"
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_needaction_counter
 msgid "Number of Actions"
-msgstr ""
+msgstr "Anzahl Aktionen"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_has_error_counter
 msgid "Number of errors"
-msgstr ""
+msgstr "Anzahl Fehler"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__message_needaction_counter
 msgid "Number of messages requiring action"
-msgstr ""
+msgstr "Anzahl der Nachrichten, die eine Aktion erfordern"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__message_has_error_counter
 msgid "Number of messages with delivery error"
-msgstr ""
+msgstr "Anzahl der Nachrichten mit Zustellfehler"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/account_bank_statement_line.py:0
 #, python-format
 msgid ""
-"On bank statement line '%(line)s', the amount (%(amount)s) is negative so it "
-"cannot be processed as a donation."
+"On bank statement line '%(line)s', the amount (%(amount)s) is negative so it"
+" cannot be processed as a donation."
 msgstr ""
+"In Kontoauszugszeile '%(line)s' ist der Betrag (%(amount)s) negativ und "
+"kann daher nicht als Spende verarbeitet werden."
 
 #. module: donation
 #. odoo-python
@@ -800,6 +807,8 @@ msgstr ""
 msgid ""
 "On bank statement line '%s', the partner is required to process a donation."
 msgstr ""
+"In Kontoauszugszeile '%s' wird ein Partner benötigt, um eine Spende zu "
+"verarbeiten."
 
 #. module: donation
 #. odoo-python
@@ -809,6 +818,8 @@ msgid ""
 "On the company %(company)s, the Product for Donations via Credit Transfer "
 "(%(product)s) is not a donation product !"
 msgstr ""
+"Im Unternehmen %(company)s ist das Produkt für Spenden per Überweisung "
+"(%(product)s) kein Spendenprodukt!"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
@@ -819,43 +830,38 @@ msgstr "Weitere Informationen"
 #: model:ir.model.fields,field_description:donation.field_donation_donation__commercial_partner_id
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
 msgid "Parent Donor"
-msgstr ""
+msgstr "Übergeordneter Spender"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
 msgid "Partner"
-msgstr "Parnter"
+msgstr "Partner"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_report__country_id
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
 msgid "Partner Country"
-msgstr "Partner Land"
+msgstr "Land des Partners"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__payment_method_line_id
-#: model:ir.model.fields,field_description:donation.field_donation_report__payment_method_line_id
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
-msgid "Payment Mode"
-msgstr ""
+msgid "Payment Method"
+msgstr "Zahlungsmethode"
 
 #. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid ""
-"Payment Mode is not set on donation %s (only fully in-kind donations don't "
-"require a payment mode)."
-msgstr ""
+#: model:ir.model.fields,field_description:donation.field_donation_report__payment_method_line_id
+msgid "Payment Method Line"
+msgstr "Zahlungsmethode"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.account_payment_method_line_donation_action
 #: model:ir.model,name:donation.model_account_payment_method_line
 #: model:ir.ui.menu,name:donation.account_payment_method_line_donation_menu
-msgid "Payment Modes"
-msgstr ""
+msgid "Payment Methods"
+msgstr "Zahlungsmethoden"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__payment_ref
@@ -863,14 +869,32 @@ msgid "Payment Reference"
 msgstr "Zahlungsreferenz"
 
 #. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid "Payment account is not set on payment method '%s'."
+msgstr "Zahlungskonto ist bei Zahlungsmethode '%s' nicht hinterlegt."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid ""
+"Payment method is not set on donation %s (only fully in-kind donations don't"
+" require a payment method)."
+msgstr ""
+"Zahlungsmethode ist bei Spende %s nicht hinterlegt (nur reine Sachspenden "
+"benötigen keine Zahlungsmethode)."
+
+#. module: donation
 #: model:ir.ui.menu,name:donation.donation_tax_receipt_print_menu
 msgid "Print Receipts"
-msgstr "Drucke Bescheinigung"
+msgstr "Bescheinigungen drucken"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
 msgid "Print Thanks Letter"
-msgstr ""
+msgstr "Dankesbrief drucken"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__product_id
@@ -885,17 +909,16 @@ msgid "Product Category"
 msgstr "Produktkategorie"
 
 #. module: donation
-#: model:ir.model.fields,field_description:donation.field_donation_line__product_detailed_type
-#: model:ir.model.fields,field_description:donation.field_donation_report__product_detailed_type
+#: model:ir.model.fields,field_description:donation.field_donation_line__product_donation_type
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
-msgid "Product Type"
-msgstr ""
+msgid "Product Type donation"
+msgstr "Produkttyp Spende"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_company__donation_credit_transfer_product_id
 #: model:ir.model.fields,field_description:donation.field_res_config_settings__donation_credit_transfer_product_id
 msgid "Product for Donations via Credit Transfer"
-msgstr ""
+msgstr "Produkt für Spenden per Überweisung"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_product_action
@@ -917,22 +940,22 @@ msgstr "Verbundene Spenden"
 #. module: donation
 #: model:ir.ui.menu,name:donation.donation_report_title_menu
 msgid "Reporting"
-msgstr ""
+msgstr "Berichte"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Verantwortlicher Benutzer"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
 msgid "Save Default Values"
-msgstr "Speicher Default Werte"
+msgstr "Standardwerte speichern"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_from_bank_statement_line_form
 msgid "Save as Draft"
-msgstr ""
+msgstr "Als Entwurf speichern"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__sequence
@@ -945,18 +968,18 @@ msgstr "Reihenfolge"
 #: model:ir.actions.act_window,name:donation.donation_settings_action
 #: model:ir.ui.menu,name:donation.donation_settings_menu
 msgid "Settings"
-msgstr ""
+msgstr "Einstellungen"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__bank_statement_line_id
 msgid "Source Bank Statement Line"
-msgstr ""
+msgstr "Quell-Kontoauszugszeile"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_line__tax_receipt_ok
 msgid "Specify if the product is eligible for a tax receipt"
 msgstr ""
-"Spezifizieren Sie hier, ob dieses Produkt für die Erstellung einer "
+"Legt fest, ob dieses Produkt für die Erstellung einer "
 "Spendenbescheinigung geeignet ist"
 
 #. module: donation
@@ -978,36 +1001,40 @@ msgid ""
 "Today: Activity date is today\n"
 "Planned: Future activities."
 msgstr ""
+"Status basierend auf Aktivitäten\n"
+"Überfällig: Fälligkeitsdatum ist bereits überschritten\n"
+"Heute: Aktivitätsdatum ist heute\n"
+"Geplant: Zukünftige Aktivitäten."
 
 #. module: donation
 #: model:ir.model,name:donation.model_donation_tax_receipt_option_switch
 msgid "Switch Donation Tax Receipt Option"
-msgstr "Ändere Spendenbescheinigung"
+msgstr "Spendenbescheinigungs-Option wechseln"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__tax_receipt_id
 #: model_terms:ir.ui.view,arch_db:donation.donation_line_tree
 msgid "Tax Receipt"
-msgstr "Steuerbeleg"
+msgstr "Spendenbescheinigung"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__tax_receipt_total
 #: model:ir.model.fields,field_description:donation.field_donation_line__tax_receipt_amount
 #: model:ir.model.fields,field_description:donation.field_donation_report__tax_receipt_amount
 msgid "Tax Receipt Eligible Amount"
-msgstr "Berechtigter Spendenbescheinigungsbetrag"
+msgstr "Bescheinigungsfähiger Betrag"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__tax_receipt_option
 #: model:ir.model.fields,field_description:donation.field_donation_tax_receipt_option_switch__new_tax_receipt_option
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
 msgid "Tax Receipt Option"
-msgstr "Spendenbescheinigung"
+msgstr "Spendenbescheinigungs-Option"
 
 #. module: donation
 #: model:ir.model,name:donation.model_donation_tax_receipt
 msgid "Tax Receipt for Donations"
-msgstr "Steuerbeleg für Spenden"
+msgstr "Spendenbescheinigung für Spenden"
 
 #. module: donation
 #: model:ir.ui.menu,name:donation.donation_tax_title_menu
@@ -1017,35 +1044,35 @@ msgstr "Spendenbescheinigungen"
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_thanks_template__text
 msgid "Text"
-msgstr ""
+msgstr "Text"
 
 #. module: donation
 #: model:ir.actions.report,name:donation.report_thanks
 msgid "Thanks Letter"
-msgstr ""
+msgstr "Dankesbrief"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_thanks_template_action
 #: model:ir.ui.menu,name:donation.donation_thanks_template_menu
 msgid "Thanks Letter Templates"
-msgstr ""
+msgstr "Dankesbrief-Vorlagen"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__thanks_printed
 #: model:ir.model.fields,field_description:donation.field_donation_report__thanks_printed
 msgid "Thanks Printed"
-msgstr ""
+msgstr "Dank gedruckt"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__thanks_template_id
 #: model:ir.model.fields,field_description:donation.field_donation_report__thanks_template_id
 msgid "Thanks Template"
-msgstr ""
+msgstr "Dankesvorlage"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
 msgid "Thanks to Print"
-msgstr ""
+msgstr "Dank zu drucken"
 
 #. module: donation
 #. odoo-python
@@ -1055,13 +1082,17 @@ msgid ""
 "The Donation by Credit Transfer Account '%(account)s' for company "
 "'%(company)s' is not reconciliable. This should never happen."
 msgstr ""
+"Das Spendenkonto für Überweisungen '%(account)s' im Unternehmen "
+"'%(company)s' ist nicht ausgleichbar. Dies sollte niemals vorkommen."
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/account_bank_statement_line.py:0
 #, python-format
-msgid "The Donation by Credit Transfer Account is not set for company '%s'."
+msgid "The Donation by Credit Transfer Accountis not set for company '%s'."
 msgstr ""
+"Das Spendenkonto für Überweisungen ist für das Unternehmen '%s' nicht "
+"eingerichtet."
 
 #. module: donation
 #. odoo-python
@@ -1071,6 +1102,8 @@ msgid ""
 "The amount of donation %(donation)s (%(check_total)s) is different from the "
 "sum of the donation lines (%(amount_total)s)."
 msgstr ""
+"Der Betrag der Spende %(donation)s (%(check_total)s) weicht von der Summe "
+"der Spendenzeilen (%(amount_total)s) ab."
 
 #. module: donation
 #. odoo-python
@@ -1078,44 +1111,18 @@ msgstr ""
 #, python-format
 msgid ""
 "The date of donation %s should be today or in the past, not in the future!"
-msgstr ""
+msgstr "Das Datum der Spende %s darf nicht in der Zukunft liegen!"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/donation.py:0
 #, python-format
 msgid ""
-"The donation '%(donation)s' is linked to the tax receipt %(tax_receipt)s, so "
-"you cannot delete it."
+"The payment method '%(pay_mode)s' selected on donation %(donation)s is not a"
+" donation payment method."
 msgstr ""
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid "The donation '%s' is in Done state, so you cannot delete it."
-msgstr ""
-"Die Spende '%s1 ist im Status 'Erledigt' und kann daher nicht gelöscht "
-"werden."
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid ""
-"The donation '%s' is linked to an account move, so you cannot delete it."
-msgstr ""
-"Die Spende '%s1 ist mit einer Kontobewegung verknüpft und kann daher nicht "
-"gelöscht werden."
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid ""
-"The payment mode '%(pay_mode)s' selected on donation %(donation)s is not a "
-"donation payment mode."
-msgstr ""
+"Die Zahlungsmethode '%(pay_mode)s' bei Spende %(donation)s ist keine "
+"Spenden-Zahlungsmethode."
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__thanks_printed
@@ -1123,6 +1130,8 @@ msgid ""
 "This field automatically becomes active when the thanks letter has been "
 "printed."
 msgstr ""
+"Dieses Feld wird automatisch aktiviert, wenn der Dankesbrief gedruckt "
+"wurde."
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_validate_form
@@ -1139,17 +1148,17 @@ msgstr "Gesamt"
 #: model:ir.model.fields,help:donation.field_res_company__donation_account_id
 #: model:ir.model.fields,help:donation.field_res_config_settings__donation_account_id
 msgid "Transfer account for donations received by credit transfer. "
-msgstr ""
+msgstr "Übergangskonto für per Überweisung erhaltene Spenden. "
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__activity_exception_decoration
 msgid "Type of the exception activity on record."
-msgstr ""
+msgstr "Art der Ausnahmeaktivität im Datensatz."
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__unit_price
 msgid "Unit Price"
-msgstr "Preis je Mengeneinheit"
+msgstr "Stückpreis"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_tax_receipt_option_switch_form
@@ -1160,7 +1169,7 @@ msgstr "Aktualisieren"
 #: model:ir.model,name:donation.model_res_users
 #: model:res.groups,name:donation.group_donation_user
 msgid "User"
-msgstr "Nutzer"
+msgstr "Benutzer"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
@@ -1174,12 +1183,12 @@ msgstr "Bestätigen"
 #: model:ir.model,name:donation.model_donation_validate
 #: model_terms:ir.ui.view,arch_db:donation.donation_validate_form
 msgid "Validate Donations"
-msgstr "Bestätige Spenden"
+msgstr "Spenden bestätigen"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_validate_action
 msgid "Validate Draft Donations"
-msgstr "Bestätige Spenden Entwürfe"
+msgstr "Spendenentwürfe bestätigen"
 
 #. module: donation
 #: model:res.groups,name:donation.group_donation_viewer
@@ -1189,12 +1198,12 @@ msgstr "Betrachter"
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__website_message_ids
 msgid "Website Messages"
-msgstr ""
+msgstr "Website-Nachrichten"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__website_message_ids
 msgid "Website communication history"
-msgstr ""
+msgstr "Website-Kommunikationsverlauf"
 
 #. module: donation
 #. odoo-python
@@ -1202,11 +1211,12 @@ msgstr ""
 #, python-format
 msgid ""
 "You cannot cancel this donation because it is linked to the tax receipt %s. "
-"You should first delete this tax receipt (but it may not be legally allowed)."
+"You should first delete this tax receipt (but it may not be legally "
+"allowed)."
 msgstr ""
-"Sie können die Spende nicht abbrechen, weil sie mit dem Steuerbeleg  %s1 "
-"verbunden ist. Sie müssen zuerst diesen Steuerbeleg löschen (aber dies mag "
-"rechtlich nicht erlaubt sein)."
+"Sie können diese Spende nicht abbrechen, da sie mit der "
+"Spendenbescheinigung %s verknüpft ist. Sie müssen zuerst diese "
+"Spendenbescheinigung löschen (was aber rechtlich nicht erlaubt sein kann)."
 
 #. module: donation
 #. odoo-python
@@ -1214,80 +1224,5 @@ msgstr ""
 #, python-format
 msgid "You cannot change the Tax Receipt Option when it is Annual."
 msgstr ""
-"Sie können nicht die Steuerbeleg Option ändern, wenn diese jährlich ist."
-
-#~ msgid "Analytic Account"
-#~ msgstr "Kostenstelle"
-
-#~ msgid "Donation Line"
-#~ msgstr "Spendenzeile"
-
-#~ msgid "Journal"
-#~ msgstr "Jurnal"
-
-#~ msgid "Search Donations"
-#~ msgstr "Suche Spenden"
-
-#, python-format
-#~ msgid ""
-#~ "The donation '%s' is linked to the tax receipt %s, so you cannot delete "
-#~ "it."
-#~ msgstr ""
-#~ "Die Spende '%s1' ist mit dem Steuerbeleg %s2 und kann daher nicht "
-#~ "gelöscht werden."
-
-#~ msgid "True"
-#~ msgstr "Wahr"
-
-#~ msgid "Users"
-#~ msgstr "Nutzer"
-
-#~ msgid "Cancelled Donation of %s"
-#~ msgstr "Abgebrochene Spende von %s1"
-
-#~ msgid ""
-#~ "Cannot validate the donation of %s because it doesn't have any lines!"
-#~ msgstr ""
-#~ "Spende %s1 kann nicht bestätigt werden, da keine Zeilen vorhanden sind!"
-
-#~ msgid "Cannot validate the donation of %s because it is not in draft state."
-#~ msgstr ""
-#~ "Die Spende %s1 kann nicht bestätigt werden, da sie sich im Entwurf-Status "
-#~ "befindet."
-
-#~ msgid "Cannot validate the donation of %s because the total amount is 0 !"
-#~ msgstr ""
-#~ "Die Spende %s1 kann nicht bestätigt werden, da der Gesamtbetrag 0 ist!"
-
-#~ msgid "Current Donation Payment Method"
-#~ msgstr "Aktuelle Zahlungsmethode"
-
-#~ msgid "Donation Payment Method"
-#~ msgstr "Zahlungsmethode"
-
-#~ msgid "Donation of %s"
-#~ msgstr "Spende von %s"
-
-#~ msgid "Draft Donation of %s"
-#~ msgstr "Spendenentwurf von %s1"
-
-#~ msgid "Missing Default Debit Account on journal '%s'."
-#~ msgstr "Fehlender Default Passivsaldo im '%s1'-Jurnal."
-
-#~ msgid "Payment Method"
-#~ msgstr "Zahlungsmethode"
-
-#~ msgid "Reports"
-#~ msgstr "Berichte"
-
-#~ msgid ""
-#~ "The amount of the donation of %s (%s) is different from the sum of the "
-#~ "donation lines (%s)."
-#~ msgstr ""
-#~ "Der Betrag der Spende von %s1 (%s2) weicht von der Summe der "
-#~ "Spendenzeilen (%s3) ab."
-
-#~ msgid ""
-#~ "The date of the donation of %s should be today or in the past, not in the "
-#~ "future!"
-#~ msgstr "Das Datum der Spende von %s darf nicht in der Zukunft liegen!"
+"Sie können die Spendenbescheinigungs-Option nicht ändern, wenn diese auf "
+"'Jährlich' gesetzt ist."

--- a/donation/i18n/de.po
+++ b/donation/i18n/de.po
@@ -950,7 +950,7 @@ msgstr "Verantwortlicher Benutzer"
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
 msgid "Save Default Values"
-msgstr "Standardwerte speichern"
+msgstr "Als Standardwerte speichern"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_from_bank_statement_line_form

--- a/donation/i18n/fr.po
+++ b/donation/i18n/fr.po
@@ -4,17 +4,17 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 8.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-05-29 23:07+0000\n"
-"PO-Revision-Date: 2015-05-29 23:07+0000\n"
-"Last-Translator: <>\n"
-"Language-Team: \n"
-"Language: \n"
+"POT-Creation-Date: 2025-01-01 00:00+0000\n"
+"PO-Revision-Date: 2026-03-16 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: French\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_partner__donation_count
@@ -25,79 +25,50 @@ msgstr "Nombre de dons"
 #. module: donation
 #: model:ir.actions.report,print_report_name:donation.report_thanks
 msgid ""
-"'donation_thanks-%s%s' % (object.number, object.state == 'draft' and '-"
-"draft' or '')"
+"'donation_thanks-%s%s' % (object.number, object.state == 'draft' and "
+"'-draft' or '')"
 msgstr ""
 
 #. module: donation
 #: model:ir.model.constraint,message:donation.constraint_donation_campaign_code_company_uniq
 msgid "A campaign with the same code already exists!"
-msgstr ""
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid "A cancelled donation should not be linked to a tax receipt"
-msgstr "Un don annulé ne devrait pas être lié à un reçu fiscal"
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid "A cancelled donation should not be linked to an account move"
-msgstr "Un don annulé ne devrait pas être lié à une écriture comptable"
+msgstr "Une campagne avec le même code existe déjà !"
 
 #. module: donation
 #: model:ir.model.constraint,message:donation.constraint_donation_donation_bank_statement_line_uniq
 msgid "A donation already exists for this bank statement line."
-msgstr ""
-
-#. module: donation
-#: model:ir.model.fields,help:donation.field_donation_line__product_detailed_type
-#: model:ir.model.fields,help:donation.field_donation_report__product_detailed_type
-msgid ""
-"A storable product is a product for which you manage stock. The Inventory "
-"app has to be installed.\n"
-"A consumable product is a product for which stock is not managed.\n"
-"A service is a non-material product you provide."
-msgstr ""
-
-#. module: donation
-#: model:ir.model.fields,field_description:donation.field_donation_donation__move_id
-msgid "Account Move"
-msgstr "Ecriture comptable"
+msgstr "Un don existe déjà pour cette ligne de relevé bancaire."
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_needaction
 msgid "Action Needed"
-msgstr ""
+msgstr "Action requise"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__active
 #: model:ir.model.fields,field_description:donation.field_donation_thanks_template__active
 msgid "Active"
-msgstr ""
+msgstr "Actif"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_ids
 msgid "Activities"
-msgstr ""
+msgstr "Activités"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_exception_decoration
 msgid "Activity Exception Decoration"
-msgstr ""
+msgstr "Marqueur d'exception d'activité"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_state
 msgid "Activity State"
-msgstr ""
+msgstr "État de l'activité"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_type_icon
 msgid "Activity Type Icon"
-msgstr ""
+msgstr "Icône du type d'activité"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__amount
@@ -122,29 +93,24 @@ msgstr "Montant dans la devise de la société"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__analytic_distribution
-msgid "Analytic"
-msgstr ""
-
-#. module: donation
-#: model:ir.model.fields,field_description:donation.field_donation_line__analytic_distribution_search
-msgid "Analytic Distribution Search"
-msgstr ""
+msgid "Analytic Distribution"
+msgstr "Distribution analytique"
 
 #. module: donation
 #: model:ir.model,name:donation.model_account_analytic_applicability
 msgid "Analytic Plan's Applicabilities"
-msgstr ""
+msgstr "Applicabilités du plan analytique"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__analytic_precision
 msgid "Analytic Precision"
-msgstr ""
+msgstr "Précision analytique"
 
 #. module: donation
 #: model:ir.model.fields.selection,name:donation.selection__donation_donation__tax_receipt_option__annual
 #: model:ir.model.fields.selection,name:donation.selection__donation_tax_receipt_option_switch__new_tax_receipt_option__annual
 msgid "Annual Tax Receipt"
-msgstr ""
+msgstr "Reçu fiscal annuel"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_campaign_form
@@ -152,12 +118,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:donation.donation_thanks_template_form
 #: model_terms:ir.ui.view,arch_db:donation.donation_thanks_template_search
 msgid "Archived"
-msgstr ""
+msgstr "Archivé"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_attachment_count
 msgid "Attachment Count"
-msgstr ""
+msgstr "Nombre de pièces jointes"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
@@ -167,13 +133,13 @@ msgstr "Retour à l'état brouillon"
 #. module: donation
 #: model:ir.model,name:donation.model_account_bank_statement_line
 msgid "Bank Statement Line"
-msgstr ""
+msgstr "Ligne de relevé bancaire"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
 msgid "Campaign"
-msgstr "Campagne de don"
+msgstr "Campagne"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
@@ -192,8 +158,31 @@ msgstr "Annulé"
 #. odoo-python
 #: code:addons/donation/models/donation.py:0
 #, python-format
+msgid ""
+"Cancelled donation '%s' is linked to a journal entry. This should never "
+"happen."
+msgstr ""
+"Le don annulé '%s' est lié à une écriture comptable. Cela ne devrait "
+"jamais arriver."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid ""
+"Cancelled donation '%s' is linked to a tax receipt. This should never "
+"happen."
+msgstr ""
+"Le don annulé '%s' est lié à un reçu fiscal. Cela ne devrait jamais "
+"arriver."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
 msgid "Cannot validate donation %s because it doesn't have any lines!"
 msgstr ""
+"Impossible de valider le don %s car il ne contient aucune ligne !"
 
 #. module: donation
 #. odoo-python
@@ -201,6 +190,7 @@ msgstr ""
 #, python-format
 msgid "Cannot validate donation %s because it is not in draft state."
 msgstr ""
+"Impossible de valider le don %s car il n'est pas à l'état brouillon."
 
 #. module: donation
 #. odoo-python
@@ -208,32 +198,38 @@ msgstr ""
 #, python-format
 msgid "Cannot validate donation %s because the total amount is 0!"
 msgstr ""
+"Impossible de valider le don %s car le montant total est 0 !"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_report__product_categ_id
 msgid "Category of Product"
-msgstr "Catégorie de produit"
+msgstr "Catégorie d'article"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
 msgid "Change"
-msgstr ""
+msgstr "Modifier"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_tax_receipt_option_switch_action
 #: model_terms:ir.ui.view,arch_db:donation.donation_tax_receipt_option_switch_form
 msgid "Change Tax Receipt Option"
-msgstr ""
+msgstr "Modifier l'option de reçu fiscal"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__check_total
 msgid "Check Amount"
-msgstr "Montant"
+msgstr "Montant de contrôle"
+
+#. module: donation
+#: model_terms:ir.ui.view,arch_db:donation.res_config_settings_donation
+msgid "Check Total"
+msgstr "Vérifier le total"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_config_settings__group_donation_check_total
 msgid "Check Total on Donations"
-msgstr ""
+msgstr "Vérifier le total sur les dons"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__code
@@ -248,7 +244,7 @@ msgstr "Code attribué pour une campagne de don"
 #. module: donation
 #: model:ir.model,name:donation.model_res_company
 msgid "Companies"
-msgstr ""
+msgstr "Sociétés"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__company_id
@@ -271,7 +267,7 @@ msgstr "Devise de la société"
 #. module: donation
 #: model:ir.model,name:donation.model_res_config_settings
 msgid "Config Settings"
-msgstr ""
+msgstr "Paramètres de configuration"
 
 #. module: donation
 #: model:ir.ui.menu,name:donation.donation_config_menu
@@ -281,7 +277,7 @@ msgstr "Configuration"
 #. module: donation
 #: model:ir.model,name:donation.model_res_partner
 msgid "Contact"
-msgstr ""
+msgstr "Contact"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__country_id
@@ -291,14 +287,14 @@ msgstr "Pays"
 #. module: donation
 #: model:ir.ui.menu,name:donation.tax_receipt_annual_create_menu
 msgid "Create Annual Receipts"
-msgstr ""
+msgstr "Créer les reçus annuels"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/account_bank_statement_line.py:0
 #, python-format
 msgid "Create Donation from Bank Statement Line"
-msgstr ""
+msgstr "Créer un don à partir d'une ligne de relevé bancaire"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__create_uid
@@ -334,8 +330,8 @@ msgstr "Campagne de don courante"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_users__context_donation_payment_method_line_id
-msgid "Current Donation Payment Mode"
-msgstr ""
+msgid "Current Donation Payment Method"
+msgstr "Méthode de paiement de don courante"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
@@ -355,19 +351,24 @@ msgid "Display Name"
 msgstr "Nom affiché"
 
 #. module: donation
+#: model:ir.model.fields,field_description:donation.field_donation_line__distribution_analytic_account_ids
+msgid "Distribution Analytic Account"
+msgstr "Comptes analytiques de distribution"
+
+#. module: donation
 #: model:ir.model.fields,field_description:donation.field_account_analytic_applicability__business_domain
 msgid "Domain"
-msgstr ""
+msgstr "Domaine"
 
 #. module: donation
 #: model:ir.model,name:donation.model_donation_donation
 #: model:ir.model.fields,field_description:donation.field_account_payment_method_line__donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__donation_id
+#: model:ir.model.fields,field_description:donation.field_donation_report__product_donation_type
 #: model:ir.model.fields,field_description:donation.field_donation_tax_receipt_option_switch__donation_id
 #: model:ir.model.fields.selection,name:donation.selection__account_analytic_applicability__business_domain__donation
 #: model:ir.module.category,name:donation.module_category_donation
 #: model:ir.ui.menu,name:donation.donation_top_menu
-#: model_terms:ir.ui.view,arch_db:donation.account_payment_method_line_search
 #: model_terms:ir.ui.view,arch_db:donation.res_config_settings_donation
 msgid "Donation"
 msgstr "Don"
@@ -378,9 +379,39 @@ msgstr "Don"
 #, python-format
 msgid ""
 "Donation %(donation)s is linked to a bank statement line, but the Donation "
-"by Credit Transfer Account is not set for company '%(company)s'. This should "
-"never happen."
+"by Credit Transfer Account is not set for company '%(company)s'. This should"
+" never happen."
 msgstr ""
+"Le don %(donation)s est lié à une ligne de relevé bancaire, mais le compte "
+"de don par virement n'est pas configuré pour la société '%(company)s'. "
+"Cela ne devrait jamais arriver."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid ""
+"Donation '%(donation)s' is linked to the tax receipt %(tax_receipt)s, so you"
+" cannot delete it."
+msgstr ""
+"Le don '%(donation)s' est lié au reçu fiscal %(tax_receipt)s, donc vous ne "
+"pouvez pas le supprimer."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid "Donation '%s' is in Done state, so you cannot delete it."
+msgstr "Le don '%s' est à l'état validé, donc vous ne pouvez pas le supprimer."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid "Donation '%s' is linked to a journal entry, so you cannot delete it."
+msgstr ""
+"Le don '%s' est lié à une écriture comptable, donc vous ne pouvez pas le "
+"supprimer."
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__campaign_id
@@ -420,34 +451,27 @@ msgstr "Numéro de don"
 #. module: donation
 #: model:ir.ui.menu,name:donation.donation_tax_receipt_menu
 msgid "Donation Tax Receipts"
-msgstr "Reçus fiscaux"
+msgstr "Reçus fiscaux de dons"
 
 #. module: donation
 #: model:ir.model,name:donation.model_donation_thanks_template
 msgid "Donation Thanks Letter Template"
-msgstr ""
+msgstr "Modèle de lettre de remerciement de don"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_company__donation_account_id
 #: model:ir.model.fields,field_description:donation.field_res_config_settings__donation_account_id
 msgid "Donation by Credit Transfer Account"
-msgstr ""
+msgstr "Compte de don par virement"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/account_payment_method_line.py:0
 #, python-format
-msgid "Donation payment mode '%s' is not an inbound payment mode."
+msgid "Donation payment method '%s'is not an inbound payment method."
 msgstr ""
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/account_payment_method_line.py:0
-#, python-format
-msgid ""
-"Donation payment mode '%s' must be configured with 'Link to Bank Account' "
-"set to 'Fixed'."
-msgstr ""
+"La méthode de paiement de don '%s' n'est pas une méthode de paiement "
+"entrant."
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_action
@@ -500,20 +524,20 @@ msgstr "Brouillon"
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__tax_receipt_total
 msgid "Eligible Tax Receipt Sub-total in Company Currency"
-msgstr "Montant éligible au reçu fiscal dans la monnaie de la société"
+msgstr "Montant éligible au reçu fiscal dans la devise de la société"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_report__tax_receipt_ok
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
 msgid "Eligible for a Tax Receipt"
-msgstr ""
+msgstr "Éligible au reçu fiscal"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/donation.py:0
 #, python-format
 msgid "Error:"
-msgstr ""
+msgstr "Erreur :"
 
 #. module: donation
 #. odoo-python
@@ -521,21 +545,22 @@ msgstr ""
 #, python-format
 msgid "Failed to get account for donation line with product '%s'."
 msgstr ""
+"Impossible de trouver le compte pour la ligne de don avec l'article '%s'."
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_follower_ids
 msgid "Followers"
-msgstr "Followers"
+msgstr "Abonnés"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_partner_ids
 msgid "Followers (Partners)"
-msgstr ""
+msgstr "Abonnés (Partenaires)"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__activity_type_icon
 msgid "Font awesome icon e.g. fa-tasks"
-msgstr ""
+msgstr "Icône Font Awesome, par ex. fa-tasks"
 
 #. module: donation
 #: model:ir.model.fields.selection,name:donation.selection__donation_donation__tax_receipt_option__each
@@ -547,19 +572,19 @@ msgstr "Pour chaque don"
 #. odoo-python
 #: code:addons/donation/models/donation.py:0
 #, python-format
-msgid "Full in-kind donation: no account move generated"
-msgstr "Don en nature: aucune écriture comptable générée"
+msgid "Full in-kind donation: no journal entry generated."
+msgstr "Don entièrement en nature : aucune écriture comptable générée."
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
 msgid "Group By"
-msgstr "Grouper par"
+msgstr "Regrouper par"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__has_message
 msgid "Has Message"
-msgstr ""
+msgstr "A un message"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__id
@@ -575,60 +600,58 @@ msgstr "ID"
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_exception_icon
 msgid "Icon"
-msgstr ""
+msgstr "Icône"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__activity_exception_icon
 msgid "Icon to indicate an exception activity."
-msgstr ""
+msgstr "Icône pour indiquer une activité en exception."
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__message_needaction
 msgid "If checked, new messages require your attention."
-msgstr ""
+msgstr "Si coché, de nouveaux messages requièrent votre attention."
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__message_has_error
 msgid "If checked, some messages have a delivery error."
-msgstr ""
+msgstr "Si coché, certains messages ont une erreur de distribution."
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_account_payment_method_line__donation
-msgid "If enabled, this payment mode will be available on donations"
-msgstr ""
+msgid "If enabled, this payment method will be available on donations"
+msgstr "Si activé, cette méthode de paiement sera disponible pour les dons"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_thanks_template__image
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__in_kind
 #: model:ir.model.fields,field_description:donation.field_donation_report__in_kind
-#: model_terms:ir.ui.view,arch_db:donation.donation_report_search
 msgid "In Kind"
+msgstr "En nature"
+
+#. module: donation
+#: model_terms:ir.ui.view,arch_db:donation.donation_report_search
+msgid "In kind"
 msgstr "En nature"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__tax_receipt_ok
 msgid "Is Eligible for a Tax Receipt"
-msgstr ""
+msgstr "Est éligible à l'émission d'un reçu fiscal"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_is_follower
 msgid "Is Follower"
-msgstr ""
+msgstr "Est abonné"
 
 #. module: donation
-#: model:ir.model.fields,field_description:donation.field_donation_campaign____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_donation____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_line____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_report____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_tax_receipt_option_switch____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_thanks_template____last_update
-#: model:ir.model.fields,field_description:donation.field_donation_validate____last_update
-msgid "Last Modified on"
-msgstr "Dernière mise à jour le"
+#: model:ir.model.fields,field_description:donation.field_donation_donation__move_id
+msgid "Journal Entry"
+msgstr "Écriture comptable"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__write_uid
@@ -653,12 +676,7 @@ msgstr "Dernière mise à jour le"
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_from_bank_statement_line_form
 msgid "Lines"
-msgstr ""
-
-#. module: donation
-#: model:ir.model.fields,field_description:donation.field_donation_donation__message_main_attachment_id
-msgid "Main Attachment"
-msgstr ""
+msgstr "Lignes"
 
 #. module: donation
 #: model:ir.module.category,description:donation.module_category_donation
@@ -673,17 +691,17 @@ msgstr "Responsable"
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_tree
 msgid "Mark all selected donation as Thanks Printed?"
-msgstr ""
+msgstr "Marquer tous les dons sélectionnés comme remerciement imprimé ?"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_tree
 msgid "Mark as Thanks Printed"
-msgstr ""
+msgstr "Marquer comme remerciement imprimé"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_has_error
 msgid "Message Delivery error"
-msgstr ""
+msgstr "Erreur de distribution du message"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_ids
@@ -692,31 +710,24 @@ msgstr "Messages"
 
 #. module: donation
 #. odoo-python
-#: code:addons/donation/models/donation.py:0
+#: code:addons/donation/models/account_bank_statement_line.py:0
 #, python-format
-msgid "Missing Outstanding Receipts Account on company '%s'."
+msgid "Missing Product for Donations via Credit Transfert for company '%s'."
 msgstr ""
+"Article manquant pour les dons par virement pour la société '%s'."
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/account_bank_statement_line.py:0
 #, python-format
-msgid "Missing Product for Donations via Credit Transfer for company '%s'."
+msgid "Missing inbound payment method linked to the bank journal '%s'."
 msgstr ""
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/account_bank_statement_line.py:0
-#, python-format
-msgid ""
-"Missing inbound payment mode linked to the bank journal '%s' configured with "
-"'Link to Bank Account' set to 'Fixed'."
-msgstr ""
+"Méthode de paiement entrant manquante liée au journal bancaire '%s'."
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__my_activity_date_deadline
 msgid "My Activity Deadline"
-msgstr ""
+msgstr "Date limite de mon activité"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__name
@@ -727,34 +738,34 @@ msgstr "Nom"
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_campaign_search
 msgid "Name or Code"
-msgstr ""
+msgstr "Nom ou code"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/donation.py:0
 #, python-format
 msgid "New"
-msgstr ""
+msgstr "Nouveau"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_date_deadline
 msgid "Next Activity Deadline"
-msgstr ""
+msgstr "Date limite de la prochaine activité"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_summary
 msgid "Next Activity Summary"
-msgstr ""
+msgstr "Résumé de la prochaine activité"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_type_id
 msgid "Next Activity Type"
-msgstr ""
+msgstr "Type de la prochaine activité"
 
 #. module: donation
 #: model:ir.model.fields.selection,name:donation.selection__donation_donation__tax_receipt_option__none
 msgid "None"
-msgstr ""
+msgstr "Aucun"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__note
@@ -764,31 +775,33 @@ msgstr "Notes"
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_needaction_counter
 msgid "Number of Actions"
-msgstr ""
+msgstr "Nombre d'actions"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_has_error_counter
 msgid "Number of errors"
-msgstr ""
+msgstr "Nombre d'erreurs"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__message_needaction_counter
 msgid "Number of messages requiring action"
-msgstr ""
+msgstr "Nombre de messages nécessitant une action"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__message_has_error_counter
 msgid "Number of messages with delivery error"
-msgstr ""
+msgstr "Nombre de messages avec une erreur de distribution"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/account_bank_statement_line.py:0
 #, python-format
 msgid ""
-"On bank statement line '%(line)s', the amount (%(amount)s) is negative so it "
-"cannot be processed as a donation."
+"On bank statement line '%(line)s', the amount (%(amount)s) is negative so it"
+" cannot be processed as a donation."
 msgstr ""
+"Sur la ligne de relevé bancaire '%(line)s', le montant (%(amount)s) est "
+"négatif et ne peut donc pas être traité comme un don."
 
 #. module: donation
 #. odoo-python
@@ -797,6 +810,8 @@ msgstr ""
 msgid ""
 "On bank statement line '%s', the partner is required to process a donation."
 msgstr ""
+"Sur la ligne de relevé bancaire '%s', le partenaire est requis pour traiter "
+"un don."
 
 #. module: donation
 #. odoo-python
@@ -806,6 +821,8 @@ msgid ""
 "On the company %(company)s, the Product for Donations via Credit Transfer "
 "(%(product)s) is not a donation product !"
 msgstr ""
+"Dans la société %(company)s, l'article pour les dons par virement "
+"(%(product)s) n'est pas un article de don !"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
@@ -832,27 +849,22 @@ msgstr "Pays du partenaire"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__payment_method_line_id
-#: model:ir.model.fields,field_description:donation.field_donation_report__payment_method_line_id
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
-msgid "Payment Mode"
-msgstr ""
+msgid "Payment Method"
+msgstr "Méthode de paiement"
 
 #. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid ""
-"Payment Mode is not set on donation %s (only fully in-kind donations don't "
-"require a payment mode)."
-msgstr ""
+#: model:ir.model.fields,field_description:donation.field_donation_report__payment_method_line_id
+msgid "Payment Method Line"
+msgstr "Méthode de paiement"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.account_payment_method_line_donation_action
 #: model:ir.model,name:donation.model_account_payment_method_line
 #: model:ir.ui.menu,name:donation.account_payment_method_line_donation_menu
-msgid "Payment Modes"
-msgstr ""
+msgid "Payment Methods"
+msgstr "Méthodes de paiement"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__payment_ref
@@ -860,14 +872,32 @@ msgid "Payment Reference"
 msgstr "Référence du paiement"
 
 #. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid "Payment account is not set on payment method '%s'."
+msgstr "Le compte de paiement n'est pas configuré sur la méthode de paiement '%s'."
+
+#. module: donation
+#. odoo-python
+#: code:addons/donation/models/donation.py:0
+#, python-format
+msgid ""
+"Payment method is not set on donation %s (only fully in-kind donations don't"
+" require a payment method)."
+msgstr ""
+"La méthode de paiement n'est pas définie sur le don %s (seuls les dons "
+"entièrement en nature ne nécessitent pas de méthode de paiement)."
+
+#. module: donation
 #: model:ir.ui.menu,name:donation.donation_tax_receipt_print_menu
 msgid "Print Receipts"
-msgstr ""
+msgstr "Imprimer les reçus"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
 msgid "Print Thanks Letter"
-msgstr ""
+msgstr "Imprimer la lettre de remerciement"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__product_id
@@ -882,17 +912,16 @@ msgid "Product Category"
 msgstr "Catégorie d'article"
 
 #. module: donation
-#: model:ir.model.fields,field_description:donation.field_donation_line__product_detailed_type
-#: model:ir.model.fields,field_description:donation.field_donation_report__product_detailed_type
+#: model:ir.model.fields,field_description:donation.field_donation_line__product_donation_type
 #: model_terms:ir.ui.view,arch_db:donation.donation_report_search
-msgid "Product Type"
-msgstr ""
+msgid "Product Type donation"
+msgstr "Type d'article don"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_company__donation_credit_transfer_product_id
 #: model:ir.model.fields,field_description:donation.field_res_config_settings__donation_credit_transfer_product_id
 msgid "Product for Donations via Credit Transfer"
-msgstr ""
+msgstr "Article pour les dons par virement"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_product_action
@@ -914,12 +943,12 @@ msgstr "Dons associés"
 #. module: donation
 #: model:ir.ui.menu,name:donation.donation_report_title_menu
 msgid "Reporting"
-msgstr ""
+msgstr "Rapports"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Utilisateur responsable"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
@@ -929,7 +958,7 @@ msgstr "Enregistrer les valeurs par défaut"
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_from_bank_statement_line_form
 msgid "Save as Draft"
-msgstr ""
+msgstr "Enregistrer comme brouillon"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__sequence
@@ -942,22 +971,22 @@ msgstr "Séquence"
 #: model:ir.actions.act_window,name:donation.donation_settings_action
 #: model:ir.ui.menu,name:donation.donation_settings_menu
 msgid "Settings"
-msgstr ""
+msgstr "Paramètres"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__bank_statement_line_id
 msgid "Source Bank Statement Line"
-msgstr ""
+msgstr "Ligne de relevé bancaire source"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_line__tax_receipt_ok
 msgid "Specify if the product is eligible for a tax receipt"
-msgstr "Spécifie si le produit est éligible au reçu fiscal."
+msgstr "Définit si l'article est éligible à l'émission d'un reçu fiscal"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_campaign__start_date
 msgid "Start Date"
-msgstr "Date de départ"
+msgstr "Date de début"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__state
@@ -973,11 +1002,15 @@ msgid ""
 "Today: Activity date is today\n"
 "Planned: Future activities."
 msgstr ""
+"Statut basé sur les activités\n"
+"En retard : la date d'échéance est dépassée\n"
+"Aujourd'hui : la date de l'activité est aujourd'hui\n"
+"Planifié : activités futures."
 
 #. module: donation
 #: model:ir.model,name:donation.model_donation_tax_receipt_option_switch
 msgid "Switch Donation Tax Receipt Option"
-msgstr ""
+msgstr "Changer l'option de reçu fiscal du don"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__tax_receipt_id
@@ -990,19 +1023,19 @@ msgstr "Reçu fiscal"
 #: model:ir.model.fields,field_description:donation.field_donation_line__tax_receipt_amount
 #: model:ir.model.fields,field_description:donation.field_donation_report__tax_receipt_amount
 msgid "Tax Receipt Eligible Amount"
-msgstr ""
+msgstr "Montant éligible au reçu fiscal"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__tax_receipt_option
 #: model:ir.model.fields,field_description:donation.field_donation_tax_receipt_option_switch__new_tax_receipt_option
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
 msgid "Tax Receipt Option"
-msgstr ""
+msgstr "Option pour le reçu fiscal"
 
 #. module: donation
 #: model:ir.model,name:donation.model_donation_tax_receipt
 msgid "Tax Receipt for Donations"
-msgstr ""
+msgstr "Reçu fiscal pour les dons"
 
 #. module: donation
 #: model:ir.ui.menu,name:donation.donation_tax_title_menu
@@ -1012,35 +1045,35 @@ msgstr "Reçus fiscaux"
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_thanks_template__text
 msgid "Text"
-msgstr ""
+msgstr "Texte"
 
 #. module: donation
 #: model:ir.actions.report,name:donation.report_thanks
 msgid "Thanks Letter"
-msgstr ""
+msgstr "Lettre de remerciement"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_thanks_template_action
 #: model:ir.ui.menu,name:donation.donation_thanks_template_menu
 msgid "Thanks Letter Templates"
-msgstr ""
+msgstr "Modèles de lettre de remerciement"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__thanks_printed
 #: model:ir.model.fields,field_description:donation.field_donation_report__thanks_printed
 msgid "Thanks Printed"
-msgstr ""
+msgstr "Remerciement imprimé"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__thanks_template_id
 #: model:ir.model.fields,field_description:donation.field_donation_report__thanks_template_id
 msgid "Thanks Template"
-msgstr ""
+msgstr "Modèle de remerciement"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
 msgid "Thanks to Print"
-msgstr ""
+msgstr "Remerciements à imprimer"
 
 #. module: donation
 #. odoo-python
@@ -1050,13 +1083,16 @@ msgid ""
 "The Donation by Credit Transfer Account '%(account)s' for company "
 "'%(company)s' is not reconciliable. This should never happen."
 msgstr ""
+"Le compte de don par virement '%(account)s' de la société '%(company)s' "
+"n'est pas lettrable. Cela ne devrait jamais arriver."
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/account_bank_statement_line.py:0
 #, python-format
-msgid "The Donation by Credit Transfer Account is not set for company '%s'."
+msgid "The Donation by Credit Transfer Accountis not set for company '%s'."
 msgstr ""
+"Le compte de don par virement n'est pas configuré pour la société '%s'."
 
 #. module: donation
 #. odoo-python
@@ -1066,6 +1102,8 @@ msgid ""
 "The amount of donation %(donation)s (%(check_total)s) is different from the "
 "sum of the donation lines (%(amount_total)s)."
 msgstr ""
+"Le montant du don %(donation)s (%(check_total)s) est différent de la somme "
+"des lignes de don (%(amount_total)s)."
 
 #. module: donation
 #. odoo-python
@@ -1074,41 +1112,19 @@ msgstr ""
 msgid ""
 "The date of donation %s should be today or in the past, not in the future!"
 msgstr ""
+"La date du don %s devrait être aujourd'hui ou dans le passé, pas dans le "
+"futur !"
 
 #. module: donation
 #. odoo-python
 #: code:addons/donation/models/donation.py:0
 #, python-format
 msgid ""
-"The donation '%(donation)s' is linked to the tax receipt %(tax_receipt)s, so "
-"you cannot delete it."
+"The payment method '%(pay_mode)s' selected on donation %(donation)s is not a"
+" donation payment method."
 msgstr ""
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid "The donation '%s' is in Done state, so you cannot delete it."
-msgstr "Le don '%s' est à l'état validé, donc vous ne pouvez pas le supprimer."
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid ""
-"The donation '%s' is linked to an account move, so you cannot delete it."
-msgstr ""
-"Le don '%s' est lié à une écriture comptable, donc vous ne pouvez pas le "
-"supprimer."
-
-#. module: donation
-#. odoo-python
-#: code:addons/donation/models/donation.py:0
-#, python-format
-msgid ""
-"The payment mode '%(pay_mode)s' selected on donation %(donation)s is not a "
-"donation payment mode."
-msgstr ""
+"La méthode de paiement '%(pay_mode)s' sélectionnée sur le don %(donation)s "
+"n'est pas une méthode de paiement de don."
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__thanks_printed
@@ -1116,6 +1132,8 @@ msgid ""
 "This field automatically becomes active when the thanks letter has been "
 "printed."
 msgstr ""
+"Ce champ s'active automatiquement lorsque la lettre de remerciement a été "
+"imprimée."
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_validate_form
@@ -1126,18 +1144,18 @@ msgstr "Cet assistant validera tous les dons brouillons sélectionnés."
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
 #: model_terms:ir.ui.view,arch_db:donation.donation_from_bank_statement_line_form
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_res_company__donation_account_id
 #: model:ir.model.fields,help:donation.field_res_config_settings__donation_account_id
 msgid "Transfer account for donations received by credit transfer. "
-msgstr ""
+msgstr "Compte de transfert pour les dons reçus par virement. "
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__activity_exception_decoration
 msgid "Type of the exception activity on record."
-msgstr ""
+msgstr "Type de l'activité d'exception sur l'enregistrement."
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__unit_price
@@ -1147,7 +1165,7 @@ msgstr "Prix unitaire"
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_tax_receipt_option_switch_form
 msgid "Update"
-msgstr ""
+msgstr "Mettre à jour"
 
 #. module: donation
 #: model:ir.model,name:donation.model_res_users
@@ -1177,17 +1195,17 @@ msgstr "Valider les dons brouillons"
 #. module: donation
 #: model:res.groups,name:donation.group_donation_viewer
 msgid "Viewer"
-msgstr ""
+msgstr "Lecteur"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__website_message_ids
 msgid "Website Messages"
-msgstr ""
+msgstr "Messages du site web"
 
 #. module: donation
 #: model:ir.model.fields,help:donation.field_donation_donation__website_message_ids
 msgid "Website communication history"
-msgstr ""
+msgstr "Historique de communication du site web"
 
 #. module: donation
 #. odoo-python
@@ -1195,8 +1213,12 @@ msgstr ""
 #, python-format
 msgid ""
 "You cannot cancel this donation because it is linked to the tax receipt %s. "
-"You should first delete this tax receipt (but it may not be legally allowed)."
+"You should first delete this tax receipt (but it may not be legally "
+"allowed)."
 msgstr ""
+"Vous ne pouvez pas annuler ce don car il est lié au reçu fiscal %s. "
+"Vous devez d'abord supprimer ce reçu fiscal (mais cela peut ne pas être "
+"légalement autorisé)."
 
 #. module: donation
 #. odoo-python
@@ -1204,129 +1226,5 @@ msgstr ""
 #, python-format
 msgid "You cannot change the Tax Receipt Option when it is Annual."
 msgstr ""
-
-#~ msgid "Analytic Account"
-#~ msgstr "Compte analytique"
-
-#~ msgid "Donation Line"
-#~ msgstr "Ligne de don"
-
-#~ msgid "Journal"
-#~ msgstr "Journal"
-
-#~ msgid "Search Donations"
-#~ msgstr "Recherche des dons"
-
-#, python-format
-#~ msgid ""
-#~ "The donation '%s' is linked to the tax receipt %s, so you cannot delete "
-#~ "it."
-#~ msgstr ""
-#~ "Le don '%s' est lié au reçu fiscal %s, donc vous ne pouvez pas le "
-#~ "supprimer."
-
-#~ msgid "Unread Messages"
-#~ msgstr "Unread Messages"
-
-#~ msgid "Users"
-#~ msgstr "Utilisateurs"
-
-#~ msgid "Cancelled Donation of %s"
-#~ msgstr "Don annulé de %s"
-
-#~ msgid ""
-#~ "Cannot validate the donation of %s because it doesn't have any lines!"
-#~ msgstr ""
-#~ "Impossible de valider le don de %s parce qu'il ne contient aucune ligne !"
-
-#~ msgid "Cannot validate the donation of %s because it is not in draft state."
-#~ msgstr ""
-#~ "Impossible de valider le don de %s parce qu'il n'est pas à l'état "
-#~ "brouillon."
-
-#, fuzzy
-#~ msgid "Cannot validate the donation of %s because the total amount is 0 !"
-#~ msgstr ""
-#~ "Impossible de valider le don de %s parce qu'il ne contient aucune ligne !"
-
-#~ msgid "Current Donation Payment Method"
-#~ msgstr "Méthode de paiement actuelle"
-
-#~ msgid "Donation Payment Method"
-#~ msgstr "Méthode de paiement de don"
-
-#~ msgid "Donation of %s"
-#~ msgstr "Don de %s"
-
-#~ msgid "Draft Donation of %s"
-#~ msgstr "Don brouillon de %s"
-
-#~ msgid "Missing Default Debit Account on journal '%s'."
-#~ msgstr "Compte de débit par défaut manquant sur le journal '%s'."
-
-#~ msgid "Payment Method"
-#~ msgstr "Méthode de paiement"
-
-#~ msgid ""
-#~ "The amount of the donation of %s (%s) is different from the sum of the "
-#~ "donation lines (%s)."
-#~ msgstr ""
-#~ "Le montant du don de %s (%s) est différent de la somme des lignes de don "
-#~ "(%s)."
-
-#~ msgid ""
-#~ "The date of the donation of %s should be today or in the past, not in the "
-#~ "future!"
-#~ msgstr ""
-#~ "La date du don de %s devrait être aujourd'hui ou dans le passé, pas dans "
-#~ "le futur !"
-
-#~ msgid ""
-#~ "The journal '%s' has the option 'Donation Payment Method', so it's type "
-#~ "should be 'Cash' or 'Bank and Checks'."
-#~ msgstr ""
-#~ "Le journal '%s' a l'option 'Méthode de paiement de don', donc il doit "
-#~ "être de type 'Espèce' ou 'Banque et chèque'."
-
-#~ msgid "Date of the last message posted on the record."
-#~ msgstr "Date of the last message posted on the record."
-
-#~ msgid "Donation Validated"
-#~ msgstr "Don validé"
-
-#~ msgid ""
-#~ "Holds the Chatter summary (number of messages, ...). This summary is "
-#~ "directly in html format in order to be inserted in kanban views."
-#~ msgstr ""
-#~ "Holds the Chatter summary (number of messages, ...). This summary is "
-#~ "directly in html format in order to be inserted in kanban views."
-
-#~ msgid "If checked new messages require your attention."
-#~ msgstr "If checked new messages require your attention."
-
-#~ msgid "In-Kind Donation"
-#~ msgstr "Don en nature"
-
-#~ msgid "Is a Follower"
-#~ msgstr "Is a Follower"
-
-#~ msgid "Last Message Date"
-#~ msgstr "Last Message Date"
-
-#~ msgid "Messages and communication history"
-#~ msgstr "Messages and communication history"
-
-#~ msgid ""
-#~ "Missing income account on product '%s' or on it's related product category"
-#~ msgstr ""
-#~ "Compte de produit manquant sur l'article '%s' ou sur sa catégorie interne "
-#~ "associée"
-
-#~ msgid "Product Template"
-#~ msgstr "Modèle d'article"
-
-#~ msgid "Summary"
-#~ msgstr "Résumé"
-
-#~ msgid "This is a donation product."
-#~ msgstr "Ceci est un article de don."
+"Vous ne pouvez pas modifier l'option de reçu fiscal lorsqu'elle est "
+"annuelle."

--- a/donation_base/i18n/de.po
+++ b/donation_base/i18n/de.po
@@ -4,23 +4,23 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2019-06-28 16:42+0000\n"
-"Last-Translator: Ben Brich <b.brich@humanilog.org>\n"
-"Language-Team: none\n"
+"POT-Creation-Date: 2025-01-01 00:00+0000\n"
+"PO-Revision-Date: 2026-03-16 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: German\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.6.1\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_res_partner__tax_receipt_count
 #: model:ir.model.fields,field_description:donation_base.field_res_users__tax_receipt_count
 msgid "# of Tax Receipts"
-msgstr "# Spendenbescheinigungen"
+msgstr "Anzahl Spendenbescheinigungen"
 
 #. module: donation_base
 #: model:ir.actions.report,print_report_name:donation_base.report_donation_tax_receipt
@@ -31,66 +31,79 @@ msgstr ""
 #: model:mail.template,body_html:donation_base.tax_receipt_email_template
 msgid ""
 "<div style=\"margin: 0px; padding: 0px;\">\n"
-"        <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
+"                <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
 "        Dear <t t-out=\"object.partner_id.name\">Alexis</t>\n"
 "                <t t-if=\"object.partner_id.parent_id\">\n"
-"                                (<i><t t-out=\"object.partner_id.parent_id."
-"name\"></t></i>)\n"
+"                                (<i>\n"
+"                    <t t-out=\"object.partner_id.parent_id.name\"/>\n"
+"                </i>)\n"
 "</t>\n"
-"    ,<br><br>\n"
+"    ,<br/><br/>\n"
 "\n"
-"    Thank you very much for your donation.<br><br>\n"
+"    Thank you very much for your donation.<br/><br/>\n"
 "\n"
-"    Please find enclosed your tax receipt <span style=\"font-weight: bold;\" "
-"t-out=\"object.number\">RECPT-2023-001</span>\n"
-"                    amounting in <span style=\"font-weight: bold;\" t-out="
-"\"format_amount(object.amount, object.currency_id) or ''\">$ 10.00</span>\n"
-"                            from <t t-out=\"object.company_id.name\">Barroux "
-"Abbey</t>.\n"
-"    <t t-if=\"not is_html_empty(user.signature)\">\n"
-"            <br><br>\n"
-"            <t t-out=\"user.signature or ''\">--<br>Mitchell Admin</t>\n"
-"    </t>\n"
-"    <br><br>\n"
+"    Please find enclosed your tax receipt <span style=\"font-weight: bold;\" t-out=\"object.number\">RECPT-2023-001</span>\n"
+"                    amounting in <span style=\"font-weight: bold;\" t-out=\"format_amount(object.amount, object.currency_id) or ''\">$ 10.00</span>\n"
+"                            from <t t-out=\"object.company_id.name\">Barroux Abbey</t>.\n"
+"    <t t-if=\"not is_html_empty(user.signature)\" data-o-mail-quote-container=\"1\">\n"
+"                    <br/>\n"
+"                    <br/>\n"
+"                    <t t-out=\"user.signature or ''\" data-o-mail-quote=\"1\">--<br data-o-mail-quote=\"1\"/>Mitchell Admin</t>\n"
+"                </t>\n"
+"    <br/><br/>\n"
 "    </p>\n"
-"    </div>\n"
-"    "
+"            </div>\n"
+"        "
 msgstr ""
-
-#. module: donation_base
-#: model:ir.model.fields,help:donation_base.field_product_product__detailed_type
-#: model:ir.model.fields,help:donation_base.field_product_template__detailed_type
-msgid ""
-"A storable product is a product for which you manage stock. The Inventory "
-"app has to be installed.\n"
-"A consumable product is a product for which stock is not managed.\n"
-"A service is a non-material product you provide."
-msgstr ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
+"        Guten Tag <t t-out=\"object.partner_id.name\">Alexis</t>\n"
+"                <t t-if=\"object.partner_id.parent_id\">\n"
+"                                (<i>\n"
+"                    <t t-out=\"object.partner_id.parent_id.name\"/>\n"
+"                </i>)\n"
+"</t>\n"
+"    ,<br/><br/>\n"
+"\n"
+"    Vielen Dank für Ihre Spende.<br/><br/>\n"
+"\n"
+"    Anbei erhalten Sie Ihre Spendenbescheinigung <span style=\"font-weight: bold;\" t-out=\"object.number\">RECPT-2023-001</span>\n"
+"                    über den Betrag von <span style=\"font-weight: bold;\" t-out=\"format_amount(object.amount, object.currency_id) or ''\">$ 10.00</span>\n"
+"                            von <t t-out=\"object.company_id.name\">Barroux Abbey</t>.\n"
+"    <t t-if=\"not is_html_empty(user.signature)\" data-o-mail-quote-container=\"1\">\n"
+"                    <br/>\n"
+"                    <br/>\n"
+"                    <t t-out=\"user.signature or ''\" data-o-mail-quote=\"1\">--<br data-o-mail-quote=\"1\"/>Mitchell Admin</t>\n"
+"                </t>\n"
+"    <br/><br/>\n"
+"    </p>\n"
+"            </div>\n"
+"        "
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_needaction
 msgid "Action Needed"
-msgstr ""
+msgstr "Handlungsbedarf"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_ids
 msgid "Activities"
-msgstr ""
+msgstr "Aktivitäten"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_exception_decoration
 msgid "Activity Exception Decoration"
-msgstr ""
+msgstr "Aktivitätsausnahme-Markierung"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_state
 msgid "Activity State"
-msgstr ""
+msgstr "Aktivitätsstatus"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_type_icon
 msgid "Activity Type Icon"
-msgstr ""
+msgstr "Aktivitätstyp-Symbol"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__amount
@@ -116,7 +129,7 @@ msgstr "Sammelspendenbescheinigungen"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_attachment_count
 msgid "Attachment Count"
-msgstr ""
+msgstr "Anzahl Anhänge"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_print_form
@@ -135,17 +148,17 @@ msgstr "Unternehmen"
 #: code:addons/donation_base/models/donation_tax_receipt.py:0
 #, python-format
 msgid "Compose Email"
-msgstr "Verfasse E-Mail"
+msgstr "E-Mail verfassen"
 
 #. module: donation_base
 #: model:ir.model,name:donation_base.model_res_partner
 msgid "Contact"
-msgstr ""
+msgstr "Kontakt"
 
 #. module: donation_base
 #: model:ir.actions.act_window,name:donation_base.tax_receipt_annual_create_action
 msgid "Create Annual Receipts"
-msgstr "Erstelle Sammelbescheinigungen"
+msgstr "Sammelbescheinigungen erstellen"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__create_uid
@@ -185,7 +198,8 @@ msgid "Display Name"
 msgstr "Anzeigename"
 
 #. module: donation_base
-#: model:ir.model.fields.selection,name:donation_base.selection__product_template__detailed_type__donation
+#: model:ir.model.fields,field_description:donation_base.field_product_product__donation_type
+#: model:ir.model.fields,field_description:donation_base.field_product_template__donation_type
 #: model:product.template,name:donation_base.product_product_donation_product_template
 #: model_terms:ir.ui.view,arch_db:donation_base.product_template_search_view
 msgid "Donation"
@@ -194,7 +208,7 @@ msgstr "Spende"
 #. module: donation_base
 #: model:product.template,name:donation_base.product_product_donation_notaxreceipt_product_template
 msgid "Donation - no tax receipt"
-msgstr "Spende- keine Spendenbescheinigung"
+msgstr "Spende - keine Spendenbescheinigung"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__donation_date
@@ -211,7 +225,7 @@ msgstr "Spendenbescheinigung"
 #. module: donation_base
 #: model:mail.template,name:donation_base.tax_receipt_email_template
 msgid "Donation Tax Receipt - Send by Email"
-msgstr ""
+msgstr "Spendenbescheinigung - per E-Mail senden"
 
 #. module: donation_base
 #: model:ir.actions.act_window,name:donation_base.donation_tax_receipt_action
@@ -228,7 +242,7 @@ msgstr "Spender"
 #: model:ir.model.fields,field_description:donation_base.field_res_partner__donor_rank
 #: model:ir.model.fields,field_description:donation_base.field_res_users__donor_rank
 msgid "Donor Rank"
-msgstr ""
+msgstr "Spenderrang"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.report_donationtaxreceipt_document
@@ -239,7 +253,7 @@ msgstr "Spender:"
 #: model:ir.actions.act_window,name:donation_base.res_partner_action_donor
 #: model_terms:ir.ui.view,arch_db:donation_base.res_partner_view_search
 msgid "Donors"
-msgstr ""
+msgstr "Spender"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.product_template_search_view
@@ -254,17 +268,17 @@ msgstr "Enddatum"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_follower_ids
 msgid "Followers"
-msgstr ""
+msgstr "Follower"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_partner_ids
 msgid "Followers (Partners)"
-msgstr ""
+msgstr "Follower (Partner)"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__activity_type_icon
 msgid "Font awesome icon e.g. fa-tasks"
-msgstr ""
+msgstr "Font-Awesome-Symbol, z.B. fa-tasks"
 
 #. module: donation_base
 #: model:ir.model.fields.selection,name:donation_base.selection__res_partner__tax_receipt_option__each
@@ -280,7 +294,7 @@ msgstr "Erzeugen"
 #: model:ir.model,name:donation_base.model_tax_receipt_annual_create
 #: model_terms:ir.ui.view,arch_db:donation_base.tax_receipt_annual_create_form
 msgid "Generate Annual Tax Receipts"
-msgstr "Erzeuge Sammelspendenbescheinigungen"
+msgstr "Sammelspendenbescheinigungen erzeugen"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_search
@@ -290,7 +304,7 @@ msgstr "Gruppieren nach"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__has_message
 msgid "Has Message"
-msgstr ""
+msgstr "Hat Nachricht"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__id
@@ -302,24 +316,25 @@ msgstr "ID"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_exception_icon
 msgid "Icon"
-msgstr ""
+msgstr "Symbol"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__activity_exception_icon
 msgid "Icon to indicate an exception activity."
-msgstr ""
+msgstr "Symbol zur Kennzeichnung einer Ausnahmeaktivität."
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__message_needaction
 msgid "If checked, new messages require your attention."
-msgstr ""
+msgstr "Wenn aktiviert, erfordern neue Nachrichten Ihre Aufmerksamkeit."
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__message_has_error
 msgid "If checked, some messages have a delivery error."
-msgstr ""
+msgstr "Wenn aktiviert, haben einige Nachrichten einen Zustellfehler."
 
 #. module: donation_base
+#: model:ir.model.fields.selection,name:donation_base.selection__product_template__donation_type__donation_in_kind
 #: model:product.template,name:donation_base.product_product_inkind_donation_product_template
 msgid "In-Kind Donation"
 msgstr "Sachspende"
@@ -327,17 +342,7 @@ msgstr "Sachspende"
 #. module: donation_base
 #: model:product.template,name:donation_base.product_product_inkind_donation_notaxreceipt_product_template
 msgid "In-Kind Donation - no tax receipt"
-msgstr "Spachspende - keine Spendenbescheinigung"
-
-#. module: donation_base
-#: model:ir.model.fields.selection,name:donation_base.selection__product_template__detailed_type__donation_in_kind_consu
-msgid "In-Kind Donation Consummable"
-msgstr ""
-
-#. module: donation_base
-#: model:ir.model.fields.selection,name:donation_base.selection__product_template__detailed_type__donation_in_kind_service
-msgid "In-Kind Donation Service"
-msgstr ""
+msgstr "Sachspende - keine Spendenbescheinigung"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_product_product__tax_receipt_ok
@@ -348,14 +353,7 @@ msgstr "Ist geeignet für Spendenbescheinigung"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_is_follower
 msgid "Is Follower"
-msgstr ""
-
-#. module: donation_base
-#: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt____last_update
-#: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt_print____last_update
-#: model:ir.model.fields,field_description:donation_base.field_tax_receipt_annual_create____last_update
-msgid "Last Modified on"
-msgstr "Zuletzt geändert am"
+msgstr "Ist Follower"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__write_uid
@@ -372,53 +370,53 @@ msgid "Last Updated on"
 msgstr "Zuletzt aktualisiert am"
 
 #. module: donation_base
-#: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_main_attachment_id
-msgid "Main Attachment"
-msgstr ""
-
-#. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_has_error
 msgid "Message Delivery error"
-msgstr ""
+msgstr "Nachrichtenzustellfehler"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_ids
 msgid "Messages"
-msgstr ""
+msgstr "Nachrichten"
 
 #. module: donation_base
 #. odoo-python
 #: code:addons/donation_base/models/donation_tax_receipt.py:0
 #, python-format
 msgid "Missing email on partner '%s'."
-msgstr "Fehlende Email bei Partner '%s'."
+msgstr "Fehlende E-Mail-Adresse bei Partner '%s'."
+
+#. module: donation_base
+#: model:ir.model.fields.selection,name:donation_base.selection__product_template__donation_type__donation
+msgid "Monetary Donation"
+msgstr "Geldspende"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__my_activity_date_deadline
 msgid "My Activity Deadline"
-msgstr ""
+msgstr "Meine Aktivitätsfrist"
 
 #. module: donation_base
 #. odoo-python
 #: code:addons/donation_base/models/donation_tax_receipt.py:0
 #, python-format
 msgid "New"
-msgstr ""
+msgstr "Neu"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_date_deadline
 msgid "Next Activity Deadline"
-msgstr ""
+msgstr "Nächste Aktivitätsfrist"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_summary
 msgid "Next Activity Summary"
-msgstr ""
+msgstr "Zusammenfassung nächste Aktivität"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_type_id
 msgid "Next Activity Type"
-msgstr ""
+msgstr "Nächster Aktivitätstyp"
 
 #. module: donation_base
 #. odoo-python
@@ -435,22 +433,22 @@ msgstr "Keine"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_needaction_counter
 msgid "Number of Actions"
-msgstr ""
+msgstr "Anzahl Aktionen"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_has_error_counter
 msgid "Number of errors"
-msgstr ""
+msgstr "Anzahl Fehler"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__message_needaction_counter
 msgid "Number of messages requiring action"
-msgstr ""
+msgstr "Anzahl der Nachrichten, die eine Aktion erfordern"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__message_has_error_counter
 msgid "Number of messages with delivery error"
-msgstr ""
+msgstr "Anzahl der Nachrichten mit Zustellfehler"
 
 #. module: donation_base
 #: model:ir.model.fields.selection,name:donation_base.selection__donation_tax_receipt__type__each
@@ -465,12 +463,12 @@ msgstr "Einmalige Spendenbescheinigungen"
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_search
 msgid "Partner"
-msgstr ""
+msgstr "Partner"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_form
 msgid "Print"
-msgstr "Druck"
+msgstr "Drucken"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__print_date
@@ -480,18 +478,18 @@ msgstr "Druckdatum"
 #. module: donation_base
 #: model:ir.model,name:donation_base.model_donation_tax_receipt_print
 msgid "Print Donation Tax Receipts"
-msgstr "Drucke Spendenbescheinigungen"
+msgstr "Spendenbescheinigungen drucken"
 
 #. module: donation_base
 #: model:ir.actions.act_window,name:donation_base.donation_tax_receipt_print_action
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_print_form
 msgid "Print Receipts"
-msgstr "Drucke Bescheinigungen"
+msgstr "Bescheinigungen drucken"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_print_form
 msgid "Print Tax Receipts"
-msgstr "Drucke Spendenbescheinigungen"
+msgstr "Spendenbescheinigungen drucken"
 
 #. module: donation_base
 #: model:ir.model,name:donation_base.model_product_template
@@ -499,15 +497,9 @@ msgid "Product"
 msgstr "Produkt"
 
 #. module: donation_base
-#: model:ir.model.fields,field_description:donation_base.field_product_product__detailed_type
-#: model:ir.model.fields,field_description:donation_base.field_product_template__detailed_type
-msgid "Product Type"
-msgstr ""
-
-#. module: donation_base
 #: model:ir.model,name:donation_base.model_product_product
 msgid "Product Variant"
-msgstr ""
+msgstr "Produktvariante"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__number
@@ -518,24 +510,24 @@ msgstr "Bescheinigungsnummer"
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt_print__receipt_ids
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_print_form
 msgid "Receipts to Print"
-msgstr ""
+msgstr "Bescheinigungen zum Drucken"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Verantwortlicher Benutzer"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_form
 msgid "Send by Email"
-msgstr "Sende per E-Mail"
+msgstr "Per E-Mail senden"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_product_product__tax_receipt_ok
 #: model:ir.model.fields,help:donation_base.field_product_template__tax_receipt_ok
 msgid "Specify if the product is eligible for a tax receipt"
 msgstr ""
-"Spezifizieren Sie hier, ob dieses Produkt für die Erstellung einer "
+"Legt fest, ob dieses Produkt für die Erstellung einer "
 "Spendenbescheinigung geeignet ist"
 
 #. module: donation_base
@@ -551,33 +543,39 @@ msgid ""
 "Today: Activity date is today\n"
 "Planned: Future activities."
 msgstr ""
+"Status basierend auf Aktivitäten\n"
+"Überfällig: Fälligkeitsdatum ist bereits überschritten\n"
+"Heute: Aktivitätsdatum ist heute\n"
+"Geplant: Zukünftige Aktivitäten."
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_res_partner__tax_receipt_option
 #: model:ir.model.fields,field_description:donation_base.field_res_users__tax_receipt_option
 msgid "Tax Receipt Option"
-msgstr "Spendenbescheinigung"
+msgstr "Spendenbescheinigungs-Option"
 
 #. module: donation_base
 #: model:ir.model,name:donation_base.model_donation_tax_receipt
 msgid "Tax Receipt for Donations"
-msgstr "Steuerbescheinigung für Spenden"
+msgstr "Spendenbescheinigung für Spenden"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_res_partner__tax_receipt_ids
 #: model:ir.model.fields,field_description:donation_base.field_res_users__tax_receipt_ids
 #: model_terms:ir.ui.view,arch_db:donation_base.view_partner_property_form
 msgid "Tax Receipts"
-msgstr "Steuerbescheinigungen"
+msgstr "Spendenbescheinigungen"
 
 #. module: donation_base
 #. odoo-python
 #: code:addons/donation_base/wizard/tax_receipt_annual_create.py:0
 #, python-format
 msgid ""
-"The Donor '%(partner)s' already has an annual tax receipt in this timeframe: "
-"%(receipt)s dated %(number)s."
+"The Donor '%(partner)s' already has an annual tax receipt in this timeframe:"
+" %(receipt)s dated %(date)s."
 msgstr ""
+"Der Spender '%(partner)s' hat bereits eine Sammelspendenbescheinigung in "
+"diesem Zeitraum: %(receipt)s vom %(date)s."
 
 #. module: donation_base
 #. odoo-python
@@ -592,8 +590,7 @@ msgstr "Es gibt keine Spendenbescheinigungen zum Drucken."
 #, python-format
 msgid "There shouldn't have any Customer Taxes on the donation product '%s'."
 msgstr ""
-"Im Produkt '%s' sind Steuern (Verkauf) ausgewählt. In Spendenprodukten "
-"dürfen keine Steuern definiert werden."
+"Im Spendenprodukt '%s' dürfen keine Verkaufssteuern definiert werden."
 
 #. module: donation_base
 #: model_terms:product.template,description:donation_base.product_product_donation_product_template
@@ -605,7 +602,7 @@ msgstr "Dieses Spendenprodukt ist geeignet für eine Spendenbescheinigung."
 #: model_terms:product.template,description:donation_base.product_product_donation_notaxreceipt_product_template
 #: model_terms:product.template,description:donation_base.product_product_inkind_donation_notaxreceipt_product_template
 msgid "This donation item is not eligible for a tax receipt."
-msgstr "Dieses Spendenprodukt ist ungeeignet für eine Spendenbescheinigung."
+msgstr "Dieses Spendenprodukt ist nicht geeignet für eine Spendenbescheinigung."
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__type
@@ -616,115 +613,19 @@ msgstr "Typ"
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__activity_exception_decoration
 msgid "Type of the exception activity on record."
-msgstr ""
+msgstr "Art der Ausnahmeaktivität im Datensatz."
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__website_message_ids
 msgid "Website Messages"
-msgstr ""
+msgstr "Website-Nachrichten"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__website_message_ids
 msgid "Website communication history"
-msgstr ""
-
-#. module: donation_base
-#: model:mail.template,report_name:donation_base.tax_receipt_email_template
-msgid ""
-"{{object.company_id.name.replace(' ', '_')}}-Tax_Receipt_{{(object.number or "
-"'').replace('/','_')}}"
-msgstr ""
+msgstr "Website-Kommunikationsverlauf"
 
 #. module: donation_base
 #: model:mail.template,subject:donation_base.tax_receipt_email_template
 msgid "{{object.company_id.name}} - Tax Receipt {{object.number or 'n/a'}}"
-msgstr ""
-
-#~ msgid "Is a Donation"
-#~ msgstr "Ist eine Spende"
-
-#, python-format
-#~ msgid ""
-#~ "The option 'In-Kind Donation' is active on the product '%s', so you must "
-#~ "also activate the option 'Is a Donation'."
-#~ msgstr ""
-#~ "Die Option 'Sachspende' ist im Produkt '%s' ausgewählt, deswegen muss "
-#~ "auch die Option 'Ist eine Spende' ausgewählt sein."
-
-#, python-format
-#~ msgid ""
-#~ "The option 'Is Eligible for a Tax Receipt' is active on the product '%s', "
-#~ "so you must also activate the option 'Is a Donation'."
-#~ msgstr ""
-#~ "The Option 'Geeignet für Spendenbescheinigung' ist im Product '%s' "
-#~ "ausgewählt, deswegen muss auch die Option 'Ist eine Spende' ausgewählt "
-#~ "sein."
-
-#~ msgid ""
-#~ "${object.company_id.name.replace(' ', '_')}-Tax_Receipt_${(object.number "
-#~ "or '').replace('/','_')}"
-#~ msgstr ""
-#~ "${object.company_id.name.replace(' ', '_')}-Spendenbescheinigung_"
-#~ "${(object.number or '').replace('/','_')}"
-
-#~ msgid "${object.company_id.name} - Tax Receipt ${object.number or 'n/a'}"
-#~ msgstr ""
-#~ "${object.company_id.name} - Spendenbescheinigung ${object.number or 'n/a'}"
-
-#~ msgid "Product Template"
-#~ msgstr "Produktvorlage"
-
-#~ msgid "Search Donation Tax Receipts"
-#~ msgstr "Suche Spendenbescheinigungen"
-
-#, python-format
-#~ msgid ""
-#~ "The Donor '%s' already has an annual tax receipt in this timeframe: %s "
-#~ "dated %s."
-#~ msgstr ""
-#~ "Der Spender '%s' hat bereits eine Sammelspendenbescheinigung für den "
-#~ "Zeitraum vom %s bis %s."
-
-#~ msgid ""
-#~ "\n"
-#~ "    <p>Dear ${object.partner_id.name}\n"
-#~ "    % if object.partner_id.parent_id:\n"
-#~ "        (<i>${object.partner_id.parent_id.name}</i>)\n"
-#~ "    % endif\n"
-#~ "    ,</p>\n"
-#~ "    \n"
-#~ "    <p>Please find enclosed your tax receipt <strong>${object.number}</"
-#~ "strong>\n"
-#~ "    amounting in <strong>${object.amount} ${object.currency_id.name}</"
-#~ "strong>\n"
-#~ "    from ${object.company_id.name}.\n"
-#~ "    </p>\n"
-#~ "    \n"
-#~ "    <p>Thank you very much for your donation.</p>\n"
-#~ "    "
-#~ msgstr ""
-#~ "\n"
-#~ "    <p>Sehr geehrte/r ${object.partner_id.name}\n"
-#~ "    % if object.partner_id.parent_id:\n"
-#~ "        (<i>${object.partner_id.parent_id.name}</i>)\n"
-#~ "    % endif\n"
-#~ "    ,</p>\n"
-#~ "    \n"
-#~ "    <p>Im Anhnag erhalten Sie Ihre Spendenbescheinigung <strong>${object."
-#~ "number}</strong>\n"
-#~ "    über den Betrag von <strong>${object.amount} ${object.currency_id."
-#~ "name}</strong>\n"
-#~ "    von ${object.company_id.name}.\n"
-#~ "    </p>\n"
-#~ "    \n"
-#~ "    <p>Vielen Dank für Ihre Spende.</p>\n"
-#~ "    "
-
-#~ msgid "Receipts To Print"
-#~ msgstr "Bescheinigungen zum drucken"
-
-#~ msgid ""
-#~ "The product '%s' is a donation, so you must configure it as a Service"
-#~ msgstr ""
-#~ "Das Produkt '%s' ist eine Spende, also muss es als Service konfiguriert "
-#~ "werden"
+msgstr "{{object.company_id.name}} - Spendenbescheinigung {{object.number or 'n/a'}}"

--- a/donation_base/i18n/fr.po
+++ b/donation_base/i18n/fr.po
@@ -4,17 +4,17 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-23 15:37+0000\n"
-"PO-Revision-Date: 2016-11-23 15:37+0000\n"
-"Last-Translator: <>\n"
-"Language-Team: \n"
-"Language: \n"
+"POT-Creation-Date: 2025-01-01 00:00+0000\n"
+"PO-Revision-Date: 2026-03-16 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: French\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_res_partner__tax_receipt_count
@@ -31,66 +31,79 @@ msgstr ""
 #: model:mail.template,body_html:donation_base.tax_receipt_email_template
 msgid ""
 "<div style=\"margin: 0px; padding: 0px;\">\n"
-"        <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
+"                <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
 "        Dear <t t-out=\"object.partner_id.name\">Alexis</t>\n"
 "                <t t-if=\"object.partner_id.parent_id\">\n"
-"                                (<i><t t-out=\"object.partner_id.parent_id."
-"name\"></t></i>)\n"
+"                                (<i>\n"
+"                    <t t-out=\"object.partner_id.parent_id.name\"/>\n"
+"                </i>)\n"
 "</t>\n"
-"    ,<br><br>\n"
+"    ,<br/><br/>\n"
 "\n"
-"    Thank you very much for your donation.<br><br>\n"
+"    Thank you very much for your donation.<br/><br/>\n"
 "\n"
-"    Please find enclosed your tax receipt <span style=\"font-weight: bold;\" "
-"t-out=\"object.number\">RECPT-2023-001</span>\n"
-"                    amounting in <span style=\"font-weight: bold;\" t-out="
-"\"format_amount(object.amount, object.currency_id) or ''\">$ 10.00</span>\n"
-"                            from <t t-out=\"object.company_id.name\">Barroux "
-"Abbey</t>.\n"
-"    <t t-if=\"not is_html_empty(user.signature)\">\n"
-"            <br><br>\n"
-"            <t t-out=\"user.signature or ''\">--<br>Mitchell Admin</t>\n"
-"    </t>\n"
-"    <br><br>\n"
+"    Please find enclosed your tax receipt <span style=\"font-weight: bold;\" t-out=\"object.number\">RECPT-2023-001</span>\n"
+"                    amounting in <span style=\"font-weight: bold;\" t-out=\"format_amount(object.amount, object.currency_id) or ''\">$ 10.00</span>\n"
+"                            from <t t-out=\"object.company_id.name\">Barroux Abbey</t>.\n"
+"    <t t-if=\"not is_html_empty(user.signature)\" data-o-mail-quote-container=\"1\">\n"
+"                    <br/>\n"
+"                    <br/>\n"
+"                    <t t-out=\"user.signature or ''\" data-o-mail-quote=\"1\">--<br data-o-mail-quote=\"1\"/>Mitchell Admin</t>\n"
+"                </t>\n"
+"    <br/><br/>\n"
 "    </p>\n"
-"    </div>\n"
-"    "
+"            </div>\n"
+"        "
 msgstr ""
-
-#. module: donation_base
-#: model:ir.model.fields,help:donation_base.field_product_product__detailed_type
-#: model:ir.model.fields,help:donation_base.field_product_template__detailed_type
-msgid ""
-"A storable product is a product for which you manage stock. The Inventory "
-"app has to be installed.\n"
-"A consumable product is a product for which stock is not managed.\n"
-"A service is a non-material product you provide."
-msgstr ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
+"        Bonjour <t t-out=\"object.partner_id.name\">Alexis</t>\n"
+"                <t t-if=\"object.partner_id.parent_id\">\n"
+"                                (<i>\n"
+"                    <t t-out=\"object.partner_id.parent_id.name\"/>\n"
+"                </i>)\n"
+"</t>\n"
+"    ,<br/><br/>\n"
+"\n"
+"    Nous vous remercions pour votre don.<br/><br/>\n"
+"\n"
+"    Veuillez trouver ci-joint votre reçu fiscal <span style=\"font-weight: bold;\" t-out=\"object.number\">RECPT-2023-001</span>\n"
+"                    d'un montant de <span style=\"font-weight: bold;\" t-out=\"format_amount(object.amount, object.currency_id) or ''\">$ 10.00</span>\n"
+"                            de la part de <t t-out=\"object.company_id.name\">Barroux Abbey</t>.\n"
+"    <t t-if=\"not is_html_empty(user.signature)\" data-o-mail-quote-container=\"1\">\n"
+"                    <br/>\n"
+"                    <br/>\n"
+"                    <t t-out=\"user.signature or ''\" data-o-mail-quote=\"1\">--<br data-o-mail-quote=\"1\"/>Mitchell Admin</t>\n"
+"                </t>\n"
+"    <br/><br/>\n"
+"    </p>\n"
+"            </div>\n"
+"        "
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_needaction
 msgid "Action Needed"
-msgstr ""
+msgstr "Action requise"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_ids
 msgid "Activities"
-msgstr ""
+msgstr "Activités"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_exception_decoration
 msgid "Activity Exception Decoration"
-msgstr ""
+msgstr "Marqueur d'exception d'activité"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_state
 msgid "Activity State"
-msgstr ""
+msgstr "État de l'activité"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_type_icon
 msgid "Activity Type Icon"
-msgstr ""
+msgstr "Icône du type d'activité"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__amount
@@ -116,7 +129,7 @@ msgstr "Reçus fiscaux annuels"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_attachment_count
 msgid "Attachment Count"
-msgstr ""
+msgstr "Nombre de pièces jointes"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_print_form
@@ -135,12 +148,12 @@ msgstr "Société"
 #: code:addons/donation_base/models/donation_tax_receipt.py:0
 #, python-format
 msgid "Compose Email"
-msgstr ""
+msgstr "Composer un e-mail"
 
 #. module: donation_base
 #: model:ir.model,name:donation_base.model_res_partner
 msgid "Contact"
-msgstr ""
+msgstr "Contact"
 
 #. module: donation_base
 #: model:ir.actions.act_window,name:donation_base.tax_receipt_annual_create_action
@@ -170,7 +183,7 @@ msgstr "Devise"
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__date
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_search
 msgid "Date"
-msgstr "Date "
+msgstr "Date"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.report_donationtaxreceipt_document
@@ -182,10 +195,11 @@ msgstr "Date :"
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt_print__display_name
 #: model:ir.model.fields,field_description:donation_base.field_tax_receipt_annual_create__display_name
 msgid "Display Name"
-msgstr "Afficher le nom"
+msgstr "Nom affiché"
 
 #. module: donation_base
-#: model:ir.model.fields.selection,name:donation_base.selection__product_template__detailed_type__donation
+#: model:ir.model.fields,field_description:donation_base.field_product_product__donation_type
+#: model:ir.model.fields,field_description:donation_base.field_product_template__donation_type
 #: model:product.template,name:donation_base.product_product_donation_product_template
 #: model_terms:ir.ui.view,arch_db:donation_base.product_template_search_view
 msgid "Donation"
@@ -211,7 +225,7 @@ msgstr "Reçu fiscal de don"
 #. module: donation_base
 #: model:mail.template,name:donation_base.tax_receipt_email_template
 msgid "Donation Tax Receipt - Send by Email"
-msgstr ""
+msgstr "Reçu fiscal de don - Envoi par e-mail"
 
 #. module: donation_base
 #: model:ir.actions.act_window,name:donation_base.donation_tax_receipt_action
@@ -228,7 +242,7 @@ msgstr "Donateur"
 #: model:ir.model.fields,field_description:donation_base.field_res_partner__donor_rank
 #: model:ir.model.fields,field_description:donation_base.field_res_users__donor_rank
 msgid "Donor Rank"
-msgstr ""
+msgstr "Rang de donateur"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.report_donationtaxreceipt_document
@@ -239,12 +253,12 @@ msgstr "Donateur :"
 #: model:ir.actions.act_window,name:donation_base.res_partner_action_donor
 #: model_terms:ir.ui.view,arch_db:donation_base.res_partner_view_search
 msgid "Donors"
-msgstr ""
+msgstr "Donateurs"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.product_template_search_view
 msgid "Eligible for a Tax Receipt"
-msgstr "Éligible reçu fiscal"
+msgstr "Éligible au reçu fiscal"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_tax_receipt_annual_create__end_date
@@ -254,17 +268,17 @@ msgstr "Date de fin"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_follower_ids
 msgid "Followers"
-msgstr ""
+msgstr "Abonnés"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_partner_ids
 msgid "Followers (Partners)"
-msgstr ""
+msgstr "Abonnés (Partenaires)"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__activity_type_icon
 msgid "Font awesome icon e.g. fa-tasks"
-msgstr ""
+msgstr "Icône Font Awesome, par ex. fa-tasks"
 
 #. module: donation_base
 #: model:ir.model.fields.selection,name:donation_base.selection__res_partner__tax_receipt_option__each
@@ -290,7 +304,7 @@ msgstr "Regrouper par"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__has_message
 msgid "Has Message"
-msgstr ""
+msgstr "A un message"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__id
@@ -302,24 +316,25 @@ msgstr "ID"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_exception_icon
 msgid "Icon"
-msgstr ""
+msgstr "Icône"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__activity_exception_icon
 msgid "Icon to indicate an exception activity."
-msgstr ""
+msgstr "Icône pour indiquer une activité en exception."
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__message_needaction
 msgid "If checked, new messages require your attention."
-msgstr ""
+msgstr "Si coché, de nouveaux messages requièrent votre attention."
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__message_has_error
 msgid "If checked, some messages have a delivery error."
-msgstr ""
+msgstr "Si coché, certains messages ont une erreur de distribution."
 
 #. module: donation_base
+#: model:ir.model.fields.selection,name:donation_base.selection__product_template__donation_type__donation_in_kind
 #: model:product.template,name:donation_base.product_product_inkind_donation_product_template
 msgid "In-Kind Donation"
 msgstr "Don en nature"
@@ -330,16 +345,6 @@ msgid "In-Kind Donation - no tax receipt"
 msgstr "Don en nature sans reçu fiscal"
 
 #. module: donation_base
-#: model:ir.model.fields.selection,name:donation_base.selection__product_template__detailed_type__donation_in_kind_consu
-msgid "In-Kind Donation Consummable"
-msgstr ""
-
-#. module: donation_base
-#: model:ir.model.fields.selection,name:donation_base.selection__product_template__detailed_type__donation_in_kind_service
-msgid "In-Kind Donation Service"
-msgstr ""
-
-#. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_product_product__tax_receipt_ok
 #: model:ir.model.fields,field_description:donation_base.field_product_template__tax_receipt_ok
 msgid "Is Eligible for a Tax Receipt"
@@ -348,14 +353,7 @@ msgstr "Est éligible à l'émission d'un reçu fiscal"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_is_follower
 msgid "Is Follower"
-msgstr ""
-
-#. module: donation_base
-#: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt____last_update
-#: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt_print____last_update
-#: model:ir.model.fields,field_description:donation_base.field_tax_receipt_annual_create____last_update
-msgid "Last Modified on"
-msgstr "Dernière Modification le"
+msgstr "Est abonné"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__write_uid
@@ -372,60 +370,60 @@ msgid "Last Updated on"
 msgstr "Dernière mise à jour le"
 
 #. module: donation_base
-#: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_main_attachment_id
-msgid "Main Attachment"
-msgstr ""
-
-#. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_has_error
 msgid "Message Delivery error"
-msgstr ""
+msgstr "Erreur de distribution du message"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_ids
 msgid "Messages"
-msgstr ""
+msgstr "Messages"
 
 #. module: donation_base
 #. odoo-python
 #: code:addons/donation_base/models/donation_tax_receipt.py:0
 #, python-format
 msgid "Missing email on partner '%s'."
-msgstr ""
+msgstr "Adresse e-mail manquante pour le partenaire '%s'."
+
+#. module: donation_base
+#: model:ir.model.fields.selection,name:donation_base.selection__product_template__donation_type__donation
+msgid "Monetary Donation"
+msgstr "Don monétaire"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__my_activity_date_deadline
 msgid "My Activity Deadline"
-msgstr ""
+msgstr "Date limite de mon activité"
 
 #. module: donation_base
 #. odoo-python
 #: code:addons/donation_base/models/donation_tax_receipt.py:0
 #, python-format
 msgid "New"
-msgstr ""
+msgstr "Nouveau"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_date_deadline
 msgid "Next Activity Deadline"
-msgstr ""
+msgstr "Date limite de la prochaine activité"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_summary
 msgid "Next Activity Summary"
-msgstr ""
+msgstr "Résumé de la prochaine activité"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_type_id
 msgid "Next Activity Type"
-msgstr ""
+msgstr "Type de la prochaine activité"
 
 #. module: donation_base
 #. odoo-python
 #: code:addons/donation_base/wizard/tax_receipt_annual_create.py:0
 #, python-format
 msgid "No annual tax receipt to generate"
-msgstr "Aucun reçu fiscal à générer"
+msgstr "Aucun reçu fiscal annuel à générer"
 
 #. module: donation_base
 #: model:ir.model.fields.selection,name:donation_base.selection__res_partner__tax_receipt_option__none
@@ -435,22 +433,22 @@ msgstr "Aucun"
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_needaction_counter
 msgid "Number of Actions"
-msgstr ""
+msgstr "Nombre d'actions"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__message_has_error_counter
 msgid "Number of errors"
-msgstr ""
+msgstr "Nombre d'erreurs"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__message_needaction_counter
 msgid "Number of messages requiring action"
-msgstr ""
+msgstr "Nombre de messages nécessitant une action"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__message_has_error_counter
 msgid "Number of messages with delivery error"
-msgstr ""
+msgstr "Nombre de messages avec une erreur de distribution"
 
 #. module: donation_base
 #: model:ir.model.fields.selection,name:donation_base.selection__donation_tax_receipt__type__each
@@ -469,9 +467,8 @@ msgstr "Partenaire"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_form
-#, fuzzy
 msgid "Print"
-msgstr "Date d'impression"
+msgstr "Imprimer"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__print_date
@@ -480,9 +477,8 @@ msgstr "Date d'impression"
 
 #. module: donation_base
 #: model:ir.model,name:donation_base.model_donation_tax_receipt_print
-#, fuzzy
 msgid "Print Donation Tax Receipts"
-msgstr "Impression du reçu fiscal"
+msgstr "Imprimer les reçus fiscaux de dons"
 
 #. module: donation_base
 #: model:ir.actions.act_window,name:donation_base.donation_tax_receipt_print_action
@@ -501,15 +497,9 @@ msgid "Product"
 msgstr "Article"
 
 #. module: donation_base
-#: model:ir.model.fields,field_description:donation_base.field_product_product__detailed_type
-#: model:ir.model.fields,field_description:donation_base.field_product_template__detailed_type
-msgid "Product Type"
-msgstr ""
-
-#. module: donation_base
 #: model:ir.model,name:donation_base.model_product_product
 msgid "Product Variant"
-msgstr ""
+msgstr "Variante d'article"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__number
@@ -520,17 +510,17 @@ msgstr "Numéro du reçu"
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt_print__receipt_ids
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_print_form
 msgid "Receipts to Print"
-msgstr ""
+msgstr "Reçus à imprimer"
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Utilisateur responsable"
 
 #. module: donation_base
 #: model_terms:ir.ui.view,arch_db:donation_base.donation_tax_receipt_form
 msgid "Send by Email"
-msgstr ""
+msgstr "Envoyer par e-mail"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_product_product__tax_receipt_ok
@@ -551,6 +541,10 @@ msgid ""
 "Today: Activity date is today\n"
 "Planned: Future activities."
 msgstr ""
+"Statut basé sur les activités\n"
+"En retard : la date d'échéance est dépassée\n"
+"Aujourd'hui : la date de l'activité est aujourd'hui\n"
+"Planifié : activités futures."
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_res_partner__tax_receipt_option
@@ -575,9 +569,11 @@ msgstr "Reçus fiscaux"
 #: code:addons/donation_base/wizard/tax_receipt_annual_create.py:0
 #, python-format
 msgid ""
-"The Donor '%(partner)s' already has an annual tax receipt in this timeframe: "
-"%(receipt)s dated %(number)s."
+"The Donor '%(partner)s' already has an annual tax receipt in this timeframe:"
+" %(receipt)s dated %(date)s."
 msgstr ""
+"Le donateur '%(partner)s' a déjà un reçu fiscal annuel dans cet intervalle "
+"de temps : %(receipt)s daté du %(date)s."
 
 #. module: donation_base
 #. odoo-python
@@ -598,13 +594,13 @@ msgstr ""
 #: model_terms:product.template,description:donation_base.product_product_donation_product_template
 #: model_terms:product.template,description:donation_base.product_product_inkind_donation_product_template
 msgid "This donation item is eligible for a tax receipt."
-msgstr "Cet article est éligible au reçu fiscal."
+msgstr "Cet article de don est éligible au reçu fiscal."
 
 #. module: donation_base
 #: model_terms:product.template,description:donation_base.product_product_donation_notaxreceipt_product_template
 #: model_terms:product.template,description:donation_base.product_product_inkind_donation_notaxreceipt_product_template
 msgid "This donation item is not eligible for a tax receipt."
-msgstr "Cet article n'est pas éligible au reçu fiscal."
+msgstr "Cet article de don n'est pas éligible au reçu fiscal."
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__type
@@ -615,76 +611,19 @@ msgstr "Type"
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__activity_exception_decoration
 msgid "Type of the exception activity on record."
-msgstr ""
+msgstr "Type de l'activité d'exception sur l'enregistrement."
 
 #. module: donation_base
 #: model:ir.model.fields,field_description:donation_base.field_donation_tax_receipt__website_message_ids
 msgid "Website Messages"
-msgstr ""
+msgstr "Messages du site web"
 
 #. module: donation_base
 #: model:ir.model.fields,help:donation_base.field_donation_tax_receipt__website_message_ids
 msgid "Website communication history"
-msgstr ""
-
-#. module: donation_base
-#: model:mail.template,report_name:donation_base.tax_receipt_email_template
-msgid ""
-"{{object.company_id.name.replace(' ', '_')}}-Tax_Receipt_{{(object.number or "
-"'').replace('/','_')}}"
-msgstr ""
+msgstr "Historique de communication du site web"
 
 #. module: donation_base
 #: model:mail.template,subject:donation_base.tax_receipt_email_template
 msgid "{{object.company_id.name}} - Tax Receipt {{object.number or 'n/a'}}"
-msgstr ""
-
-#~ msgid "Is a Donation"
-#~ msgstr "Est un don"
-
-#, python-format
-#~ msgid ""
-#~ "The option 'In-Kind Donation' is active on the product '%s', so you must "
-#~ "also activate the option 'Is a Donation'."
-#~ msgstr ""
-#~ "L'option 'Don en nature' est activée sur l'article '%s', donc vous devez "
-#~ "également activer l'option 'Est un don'."
-
-#, python-format
-#~ msgid ""
-#~ "The option 'Is Eligible for a Tax Receipt' is active on the product '%s', "
-#~ "so you must also activate the option 'Is a Donation'."
-#~ msgstr ""
-#~ "L'option 'Éligible au reçu fiscal' est activée sur l'article '%s', donc "
-#~ "vous devez également activer l'option 'Est un don'."
-
-#~ msgid "Product Template"
-#~ msgstr "Modèle d'article"
-
-#, fuzzy
-#~ msgid "Search Donation Tax Receipts"
-#~ msgstr "Rechercher dans les reçus fiscaux"
-
-#, python-format
-#~ msgid ""
-#~ "The Donor '%s' already has an annual tax receipt in this timeframe: %s "
-#~ "dated %s."
-#~ msgstr ""
-#~ "Le donateur '%s' a déjà un reçu fiscal annuel dans cet intervalle de "
-#~ "temps: %s daté du %s."
-
-#~ msgid "Receipts To Print"
-#~ msgstr "Reçus à imprimer"
-
-#~ msgid ""
-#~ "The product '%s' is a donation, so you must configure it as a Service"
-#~ msgstr "L'article '%s' est un don, donc il doit être de type 'service'"
-
-#~ msgid "Donation Taxes Receipts"
-#~ msgstr "Reçus fiscaux de dons"
-
-#~ msgid "Generate Annual Tax Receipt"
-#~ msgstr "Générer les reçus fiscaux annuels"
-
-#~ msgid "Specify if the product can be selected in a donation line."
-#~ msgstr "Définit si l'article peut être sélectionné dans une ligne de don."
+msgstr "{{object.company_id.name}} - Reçu fiscal {{object.number or 'n/a'}}"


### PR DESCRIPTION
## Summary

Complete rewrite of German (DE) and French (FR) translation files for `donation_base` and `donation` modules, aligned with the v18.0 `.pot` templates.

## Translation Coverage Improvement

| File | Before | After |
|------|--------|-------|
| `donation_base/i18n/de.po` | 55% (58/106) | **99% (99/100)** |
| `donation_base/i18n/fr.po` | 53% (56/106) | **99% (99/100)** |
| `donation/i18n/de.po` | 49% (95/192) | **99% (190/191)** |
| `donation/i18n/fr.po` | 42% (81/192) | **99% (190/191)** |

The only untranslated entry in each file is the `print_report_name` code expression, which is not user-facing.

## Changes

### New translations (~190 strings)
- All previously empty entries are now translated, including:
  - Error messages and validation warnings
  - Activity/messaging system fields
  - Thanks letter template fields
  - Bank statement line / credit transfer fields
  - Payment method fields (updated from old "Payment Mode" terminology)

### Bug fixes
- **DE typo**: `Spachspende` → `Sachspende` (In-Kind Donation - no tax receipt)
- **DE typo**: `Parnter` → `Partner`
- **DE typo**: `%s1` → `%s` in multiple error message translations
- **FR fuzzy match error**: `Print` was incorrectly translated as `Date d'impression` (Print Date) — now correctly `Imprimer`
- **FR trailing space**: `Date ` → `Date` in donation_base

### Consistency improvements
- **DE**: Standardized on `Spendenbescheinigung` for "Tax Receipt" throughout (was inconsistently mixed with `Steuerbescheinigung` and `Steuerbeleg`)
- **FR**: Standardized on `Nom affiché` for "Display Name" (was inconsistent between `Afficher le nom` and `Nom affiché`)
- **FR**: Removed all `#, fuzzy` markers with proper translations

### Cleanup
- Removed ~100 stale/obsolete entries referencing fields from Odoo v8/v10 that no longer exist in v18 (e.g., `detailed_type`, `__last_update`, old `payment mode` field names, old `account move` terminology)
- Updated `.po` file headers from `Odoo Server 8.0`/`10.0` to `18.0`
- Translated email template `body_html` and `subject` for donation_base (DE+FR)