### PR TITLE
[FIX] donation_base: use default_res_ids instead of deprecated default_res_id

### DIFF
--- a/donation_base/models/donation_tax_receipt.py
+++ b/donation_base/models/donation_tax_receipt.py
@@ -79,10 +79,10 @@ class DonationTaxReceipt(models.Model):
                 _("Missing email on partner '%s'.") % self.partner_id.display_name
             )
         template = self.env.ref("donation_base.tax_receipt_email_template")
-        layout_xmlid = "donation_base.tax_receipt_email_template"
+        layout_xmlid = "mail.mail_notification_light"
         ctx = dict(
             default_model=self._name,
-            default_res_id=self.id,
+            default_res_ids=self.ids,
             default_use_template=bool(template),
             default_template_id=template.id,
             default_composition_mode="comment",


### PR DESCRIPTION
## Summary
Fixes two bugs in `action_send_tax_receipt` that prevent sending tax receipt confirmation emails in Odoo 18.0.
### Bug 1: Deprecated `default_res_id` context key
`mail.compose.message.default_get()` raises a `ValueError` when `default_res_id` is passed in context, as it has been replaced by `default_res_ids` in Odoo 18.0.
```
ValueError: Deprecated usage of 'default_res_id', should use 'default_res_ids'.
```
### Bug 2: Wrong XML ID for `default_email_layout_xmlid`
`default_email_layout_xmlid` was set to `donation_base.tax_receipt_email_template`, which is a `mail.template` record. This context key expects an `ir.ui.view` QWeb email layout, causing an `AssertionError` in `ir.ui.view._get_view_id`.
```
AssertionError: Call _get_view_id, expected 'ir.ui.view', got 'mail.template'
```
## Fix
```diff
- default_res_id=self.id,
+ default_res_ids=self.ids,
```
```diff
- layout_xmlid = "donation_base.tax_receipt_email_template"
+ layout_xmlid = "mail.mail_notification_light"
```