### PR TITLE
[18.0][FIX] donation: fix partner donation count always showing 0

### DIFF
--- a/donation/models/res_partner.py
+++ b/donation/models/res_partner.py
@@ -23,7 +23,7 @@ class ResPartner(models.Model):
             groupby=["partner_id"],
             aggregates=["__count"],
         )
-        mapped_data = {partner: count for (partner, count) in rg_res}
+        mapped_data = {partner.id: count for (partner, count) in rg_res}
         for partner in self:
             partner.donation_count = mapped_data.get(partner.id, 0)
 


### PR DESCRIPTION
## Summary

- Fix `donation_count` smart button on the partner form always displaying 0, even when the partner has confirmed donations.

## Root Cause

In Odoo 18.0, `_read_group()` returns **recordsets** as group keys, not integer IDs. The `mapped_data` dictionary in `_compute_donation_count` was keyed by `res.partner` record objects, but the subsequent lookup used `partner.id` (an integer). Since a record object never equals an integer, `.get(partner.id, 0)` always fell through to the default `0`.

## Fix

Use `partner.id` as the dictionary key when building `mapped_data` so the lookup types match.