### PR TITLE
fix: set thanks_printed when printing thanks letters via report binding

### DIFF
--- a/donation/i18n/de.po
+++ b/donation/i18n/de.po
@@ -428,7 +428,7 @@ msgstr "Spendenbescheinigung"
 #. module: donation
 #: model:ir.model,name:donation.model_donation_thanks_template
 msgid "Donation Thanks Letter Template"
-msgstr ""
+msgstr "Vorlage für Spenden-Dankesbrief"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_company__donation_account_id
@@ -674,16 +674,6 @@ msgid "Manager"
 msgstr "Manager"
 
 #. module: donation
-#: model_terms:ir.ui.view,arch_db:donation.donation_tree
-msgid "Mark all selected donation as Thanks Printed?"
-msgstr ""
-
-#. module: donation
-#: model_terms:ir.ui.view,arch_db:donation.donation_tree
-msgid "Mark as Thanks Printed"
-msgstr ""
-
-#. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_has_error
 msgid "Message Delivery error"
 msgstr ""
@@ -868,9 +858,10 @@ msgid "Print Receipts"
 msgstr "Drucke Bescheinigung"
 
 #. module: donation
+#: model:ir.actions.server,name:donation.action_print_thanks
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
 msgid "Print Thanks Letter"
-msgstr ""
+msgstr "Dankesbrief drucken"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__product_id
@@ -1022,30 +1013,30 @@ msgstr ""
 #. module: donation
 #: model:ir.actions.report,name:donation.report_thanks
 msgid "Thanks Letter"
-msgstr ""
+msgstr "Dankesbrief"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_thanks_template_action
 #: model:ir.ui.menu,name:donation.donation_thanks_template_menu
 msgid "Thanks Letter Templates"
-msgstr ""
+msgstr "Dankesbrief-Vorlagen"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__thanks_printed
 #: model:ir.model.fields,field_description:donation.field_donation_report__thanks_printed
 msgid "Thanks Printed"
-msgstr ""
+msgstr "Dank gedruckt"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__thanks_template_id
 #: model:ir.model.fields,field_description:donation.field_donation_report__thanks_template_id
 msgid "Thanks Template"
-msgstr ""
+msgstr "Dankesvorlage"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
 msgid "Thanks to Print"
-msgstr ""
+msgstr "Dank zu drucken"
 
 #. module: donation
 #. odoo-python
@@ -1123,6 +1114,8 @@ msgid ""
 "This field automatically becomes active when the thanks letter has been "
 "printed."
 msgstr ""
+"Dieses Feld wird automatisch aktiviert, wenn der Dankesbrief gedruckt "
+"wurde."
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_validate_form

--- a/donation/i18n/fr.po
+++ b/donation/i18n/fr.po
@@ -425,7 +425,7 @@ msgstr "Reçus fiscaux"
 #. module: donation
 #: model:ir.model,name:donation.model_donation_thanks_template
 msgid "Donation Thanks Letter Template"
-msgstr ""
+msgstr "Modèle de lettre de remerciement pour don"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_res_company__donation_account_id
@@ -671,16 +671,6 @@ msgid "Manager"
 msgstr "Responsable"
 
 #. module: donation
-#: model_terms:ir.ui.view,arch_db:donation.donation_tree
-msgid "Mark all selected donation as Thanks Printed?"
-msgstr ""
-
-#. module: donation
-#: model_terms:ir.ui.view,arch_db:donation.donation_tree
-msgid "Mark as Thanks Printed"
-msgstr ""
-
-#. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__message_has_error
 msgid "Message Delivery error"
 msgstr ""
@@ -865,9 +855,10 @@ msgid "Print Receipts"
 msgstr ""
 
 #. module: donation
+#: model:ir.actions.server,name:donation.action_print_thanks
 #: model_terms:ir.ui.view,arch_db:donation.donation_form
 msgid "Print Thanks Letter"
-msgstr ""
+msgstr "Imprimer la lettre de remerciement"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_line__product_id
@@ -1017,30 +1008,30 @@ msgstr ""
 #. module: donation
 #: model:ir.actions.report,name:donation.report_thanks
 msgid "Thanks Letter"
-msgstr ""
+msgstr "Lettre de remerciement"
 
 #. module: donation
 #: model:ir.actions.act_window,name:donation.donation_thanks_template_action
 #: model:ir.ui.menu,name:donation.donation_thanks_template_menu
 msgid "Thanks Letter Templates"
-msgstr ""
+msgstr "Modèles de lettres de remerciement"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__thanks_printed
 #: model:ir.model.fields,field_description:donation.field_donation_report__thanks_printed
 msgid "Thanks Printed"
-msgstr ""
+msgstr "Remerciement imprimé"
 
 #. module: donation
 #: model:ir.model.fields,field_description:donation.field_donation_donation__thanks_template_id
 #: model:ir.model.fields,field_description:donation.field_donation_report__thanks_template_id
 msgid "Thanks Template"
-msgstr ""
+msgstr "Modèle de remerciement"
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_search
 msgid "Thanks to Print"
-msgstr ""
+msgstr "Remerciements à imprimer"
 
 #. module: donation
 #. odoo-python
@@ -1116,6 +1107,8 @@ msgid ""
 "This field automatically becomes active when the thanks letter has been "
 "printed."
 msgstr ""
+"Ce champ devient automatiquement actif lorsque la lettre de remerciement a "
+"été imprimée."
 
 #. module: donation
 #: model_terms:ir.ui.view,arch_db:donation.donation_validate_form

--- a/donation/models/donation.py
+++ b/donation/models/donation.py
@@ -637,17 +637,12 @@ class DonationDonation(models.Model):
             return res
 
     def print_thanks(self):
-        self.ensure_one()
         self.write({"thanks_printed": True})
-        action = (
+        return (
             self.env.ref("donation.report_thanks")
             .with_context(discard_logo_check=True)
             .report_action(self)
         )
-        return action
-
-    def thanks_printed_button(self):
-        self.write({"thanks_printed": True})
 
 
 class DonationLine(models.Model):

--- a/donation/report/donation_thanks_report.xml
+++ b/donation/report/donation_thanks_report.xml
@@ -15,6 +15,14 @@
         <field
             name="print_report_name"
         >'donation_thanks-%s%s' % (object.number, object.state == 'draft' and '-draft' or '')</field>
+        <field name="binding_model_id" eval="False" />
+    </record>
+
+    <record id="action_print_thanks" model="ir.actions.server">
+        <field name="name">Print Thanks Letter</field>
+        <field name="model_id" ref="model_donation_donation" />
         <field name="binding_model_id" ref="model_donation_donation" />
+        <field name="state">code</field>
+        <field name="code">action = records.print_thanks()</field>
     </record>
 </odoo>

--- a/donation/tests/__init__.py
+++ b/donation/tests/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_donation
+from . import test_donation_thanks

--- a/donation/tests/test_donation_thanks.py
+++ b/donation/tests/test_donation_thanks.py
@@ -1,0 +1,185 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import time
+
+from odoo import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestDonationThanks(TransactionCase):
+    at_install = False
+    post_install = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.company = cls.env.ref("base.main_company")
+        cls.bank_journal = cls.env["account.journal"].create(
+            {
+                "type": "bank",
+                "name": "test bank journal thanks",
+                "company_id": cls.company.id,
+            }
+        )
+        cls.payment_account = cls.env["account.account"].create(
+            {
+                "name": "Donation Payment account thanks",
+                "code": "TESTDONTHANKS",
+                "company_ids": [Command.set([cls.company.id])],
+                "account_type": "asset_current",
+                "reconcile": True,
+            }
+        )
+        cls.payment_method_line = cls.env["account.payment.method.line"].create(
+            {
+                "name": "test_payment_method_line_thanks",
+                "company_id": cls.company.id,
+                "payment_account_id": cls.payment_account.id,
+                "donation": True,
+                "journal_id": cls.bank_journal.id,
+                "payment_method_id": cls.env.ref(
+                    "account.account_payment_method_manual_in"
+                ).id,
+            }
+        )
+        cls.product = cls.env.ref("donation_base.product_product_donation")
+        today = time.strftime("%Y-%m-%d")
+        cls.ddo = cls.env["donation.donation"]
+
+        # Create three donations and validate them (thanks letter only
+        # makes sense for confirmed donations).
+        donation_vals = {
+            "company_id": cls.company.id,
+            "donation_date": today,
+            "payment_method_line_id": cls.payment_method_line.id,
+            "tax_receipt_option": "none",
+        }
+        cls.donor1 = cls.env["res.partner"].create({"name": "Thanks donor 1"})
+        cls.donor2 = cls.env["res.partner"].create({"name": "Thanks donor 2"})
+        cls.donor3 = cls.env["res.partner"].create({"name": "Thanks donor 3"})
+
+        cls.don1 = cls.ddo.create(
+            {
+                **donation_vals,
+                "check_total": 100,
+                "partner_id": cls.donor1.id,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "product_id": cls.product.id,
+                            "quantity": 1,
+                            "unit_price": 100,
+                        }
+                    )
+                ],
+            }
+        )
+        cls.don2 = cls.ddo.create(
+            {
+                **donation_vals,
+                "check_total": 200,
+                "partner_id": cls.donor2.id,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "product_id": cls.product.id,
+                            "quantity": 1,
+                            "unit_price": 200,
+                        }
+                    )
+                ],
+            }
+        )
+        cls.don3 = cls.ddo.create(
+            {
+                **donation_vals,
+                "check_total": 300,
+                "partner_id": cls.donor3.id,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "product_id": cls.product.id,
+                            "quantity": 1,
+                            "unit_price": 300,
+                        }
+                    )
+                ],
+            }
+        )
+        (cls.don1 | cls.don2 | cls.don3).validate()
+
+    def test_thanks_printed_default(self):
+        """thanks_printed defaults to False on new donations."""
+        self.assertFalse(self.don1.thanks_printed)
+        self.assertFalse(self.don2.thanks_printed)
+        self.assertFalse(self.don3.thanks_printed)
+
+    def test_print_thanks_single(self):
+        """print_thanks() on a single record sets thanks_printed and returns
+        a report action."""
+        self.assertFalse(self.don1.thanks_printed)
+        action = self.don1.print_thanks()
+        self.assertTrue(self.don1.thanks_printed)
+        # The action must be a dict pointing at the thanks report.
+        self.assertIsInstance(action, dict)
+        self.assertEqual(action.get("type"), "ir.actions.report")
+        self.assertEqual(action.get("report_name"), "donation.report_donation_thanks")
+
+    def test_print_thanks_multi(self):
+        """print_thanks() on a multi-record recordset sets thanks_printed
+        on every record."""
+        donations = self.don1 | self.don2 | self.don3
+        for don in donations:
+            self.assertFalse(don.thanks_printed)
+        action = donations.print_thanks()
+        for don in donations:
+            self.assertTrue(don.thanks_printed)
+        self.assertIsInstance(action, dict)
+        self.assertEqual(action.get("type"), "ir.actions.report")
+
+    def test_print_thanks_idempotent(self):
+        """Calling print_thanks() twice does not raise and the flag
+        stays True."""
+        self.don1.print_thanks()
+        self.assertTrue(self.don1.thanks_printed)
+        # Second call should not fail.
+        action = self.don1.print_thanks()
+        self.assertTrue(self.don1.thanks_printed)
+        self.assertIsInstance(action, dict)
+
+    def test_thanks_printed_not_copied(self):
+        """thanks_printed is not carried over when duplicating a donation."""
+        self.don1.print_thanks()
+        self.assertTrue(self.don1.thanks_printed)
+        don_copy = self.don1.copy()
+        self.assertFalse(don_copy.thanks_printed)
+
+    def test_thanks_template_not_copied(self):
+        """thanks_template_id is not carried over when duplicating."""
+        template = self.env["donation.thanks.template"].create(
+            {"name": "Test template"}
+        )
+        self.don1.thanks_template_id = template
+        don_copy = self.don1.copy()
+        self.assertFalse(don_copy.thanks_template_id)
+
+    def test_server_action_calls_print_thanks(self):
+        """The ir.actions.server bound to donation.donation invokes
+        print_thanks() which sets thanks_printed on all selected records."""
+        donations = self.don1 | self.don2
+        for don in donations:
+            self.assertFalse(don.thanks_printed)
+        server_action = self.env.ref("donation.action_print_thanks")
+        server_action.with_context(
+            active_model="donation.donation",
+            active_ids=donations.ids,
+        ).run()
+        for don in donations:
+            self.assertTrue(don.thanks_printed)
+
+    def test_report_not_bound_to_model(self):
+        """The ir.actions.report should not be directly bound to the model
+        (the server action handles the binding instead)."""
+        report = self.env.ref("donation.report_thanks")
+        self.assertFalse(report.binding_model_id)

--- a/donation/views/donation.xml
+++ b/donation/views/donation.xml
@@ -246,14 +246,6 @@
                         groups="donation.group_donation_user"
                         invisible="context.get('recurring_view')"
                     />
-                    <button
-                        name="thanks_printed_button"
-                        type="object"
-                        string="Mark as Thanks Printed"
-                        groups="donation.group_donation_user"
-                        invisible="context.get('recurring_view')"
-                        confirm="Mark all selected donation as Thanks Printed?"
-                    />
                     <!-- Unfortunately, confirm="" doesn't work for
                             buttons in list view... at least not in v14 -->
                 </header>


### PR DESCRIPTION
## Summary

When printing thanks letters from the list view using multi-select and the Print menu (report binding), the `thanks_printed` flag on `donation.donation` is not set to `True`. The same action from the form view button works differently: the `thanks_printed` flag on `donation.donation` is set automatically.

I'm not sure if this is actually a feature or a bug, but from a UX perspective it's inconsistent behaviour and thus feels like a bug.

## Why this approach
The root cause is that the report `donation.report_thanks` was bound directly to the model via `binding_model_id`. When triggered from the Print menu, Odoo's report machinery generates the PDF without ever calling `print_thanks()`, so the flag is never set.
I considered two alternatives before settling on the current approach:
1. **Override `ir.actions.report._render_qweb_pdf`** to set the flag whenever the thanks report is rendered. I discarded this because it patches a global model for a domain-specific concern — a disproportionate side effect for what is essentially a flag toggle. It also couples the flag-setting to the PDF rendering pipeline, which makes the behaviour harder to reason about and test.
2. **Override `_render_qweb_pdf_prepare_streams`** (the canonical extension point used by core modules like `purchase`, `account`, `l10n_ch`). While more idiomatic than option 1, those core overrides exist to *modify PDF content* (embed XML, merge documents), not to set business flags. Using the same hook for a different purpose felt like a misuse of the pattern.
Instead, I replaced the direct report binding with an `ir.actions.server` that calls `print_thanks()`. This follows the same pattern as `purchase.order.print_quotation()` — set the flag, then return the report action — and ensures a single code path for both form and list view. No global model overrides needed.
The "Mark as Thanks Printed" list header button became redundant (it only set the flag without printing) and was removed.